### PR TITLE
ci: use posthog-android's GPG secret names and document releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,9 +190,8 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           ./gradlew publishAllPublicationsToMavenCentralRepository \
             --no-daemon \

--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ cd posthog-kmp
 ./gradlew allTests
 ```
 
+### Releasing
+
+Releases are semi-automatic: changesets merged to `main` trigger the release pipeline, which waits for approval in the `#approvals-client-libraries` Slack channel. See [RELEASING.md](RELEASING.md) for details.
+
 ## License
 
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,9 +50,9 @@ Every release requires approval from the Client Libraries team via the `Release`
 The `Release` workflow depends on the following being set up (see the [handbook](https://posthog.com/handbook/engineering/sdks/releases)):
 
 - **`Release` GitHub environment** with required reviewers and the `GH_APP_POSTHOG_KMP_RELEASER_APP_ID` / `GH_APP_POSTHOG_KMP_RELEASER_PRIVATE_KEY` secrets (a dedicated `Releaser (posthog-kmp)` GitHub App).
-- **Maven Central publishing secrets**: `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, and the GPG signing key as `SIGNING_KEY`, `SIGNING_KEY_ID`, `SIGNING_PASSWORD` (vanniktech in-memory format).
+- **Maven Central publishing secrets**: `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, and the GPG signing key as `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE` (same names as posthog-android).
 - **Org secrets/vars** scoped to the repo: `SLACK_CLIENT_LIBRARIES_BOT_TOKEN`, `POSTHOG_PROJECT_API_KEY`, `SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID`, `GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID`.
 
 ## Rotating Sonatype / GPG credentials
 
-See [posthog-android's RELEASING.md](https://github.com/PostHog/posthog-android/blob/main/RELEASING.md#rotating-sonatype-user-token) — the Sonatype user token and GPG key are shared PostHog credentials and rotate the same way. Note that this repo consumes the GPG key under the vanniktech names (`SIGNING_KEY`/`SIGNING_KEY_ID`/`SIGNING_PASSWORD`) rather than `GPG_PRIVATE_KEY`/`GPG_PASSPHRASE`.
+See [posthog-android's RELEASING.md](https://github.com/PostHog/posthog-android/blob/main/RELEASING.md#rotating-sonatype-user-token) — the Sonatype user token and GPG key are shared PostHog credentials and rotate the same way, under the same secret names.


### PR DESCRIPTION
## Problem

Two gaps from the [SDK release setup handbook](https://posthog.com/handbook/engineering/sdks/releases):

- The release workflow read the GPG signing key from `SIGNING_KEY`/`SIGNING_KEY_ID`/`SIGNING_PASSWORD`, but the shared PostHog credentials are provisioned under posthog-android's names (`GPG_PRIVATE_KEY`/`GPG_PASSPHRASE`), now scoped to this repo as org secrets.
- The README didn't mention how releases work (handbook step 7).

## Changes

- `release.yml` reads `GPG_PRIVATE_KEY`/`GPG_PASSPHRASE`; the key ID line is dropped (not needed when signing with the primary key — same two-arg in-memory signing posthog-android uses).
- `RELEASING.md` documents the same names and drops the now-obsolete naming caveat.
- README gains a short Releasing section pointing at `RELEASING.md` and `#approvals-client-libraries`.

No SDK code changes, so no changeset.