### PR TITLE
chore: add changeset for initial 0.0.1 release

### DIFF
--- a/.sampo/changesets/calm-hedgehog-ships.md
+++ b/.sampo/changesets/calm-hedgehog-ships.md
@@ -1,0 +1,5 @@
+---
+posthog-kmp: patch
+---
+
+Initial public release of the PostHog Kotlin Multiplatform SDK: event capture, user identification, feature flags, group analytics, screen tracking, error tracking, session recording (Android/iOS), and session management for Android, iOS, and Web (JS).


### PR DESCRIPTION
## Problem

Nothing has been published to Maven Central yet — the release pipeline has never run.

## Changes

Adds a single patch changeset describing the initial SDK surface. Merging this triggers the release workflow: version bump to 0.0.1, approval request in `#approvals-client-libraries`, then publish to Maven Central.

**Merge order:** after #7, which fixes the GPG secret names the publish step reads.