### PR TITLE
ci: regenerate stale kotlin-js yarn.lock and verify it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
 
       - name: Build JS
-        run: ./gradlew :posthog-kmp:compileKotlinJs --no-daemon
+        run: ./gradlew :posthog-kmp:compileKotlinJs kotlinStoreYarnLock --no-daemon
 
   ios:
     name: iOS Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,40 @@ jobs:
 
       - name: Build iOS
         run: ./gradlew :posthog-kmp:compileKotlinIosArm64 --no-daemon
+
+  release-dry-run:
+    name: Release Dry Run
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '20'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+
+      # Mirror the release workflow (version bump, build, tests, artifact
+      # assembly) without credentials or side effects. iOS targets are
+      # skipped on Linux; the iOS Build job covers those.
+      - name: Bump version like a release would
+        run: ./scripts/bump-version.sh 9.9.9
+
+      - name: Build all targets
+        run: ./gradlew build --no-daemon
+
+      - name: Run tests
+        run: ./gradlew allTests --no-daemon
+
+      - name: Assemble publications (no upload, signing skipped without key)
+        run: ./gradlew publishToMavenLocal --no-daemon

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -233,14 +233,14 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@posthog/core@^1.38.0", "@posthog/core@^1.39.6":
+"@posthog/core@^1.39.6":
   version "1.39.6"
   resolved "https://registry.yarnpkg.com/@posthog/core/-/core-1.39.6.tgz#31110701f2d2cbe33a15967d5d2f57680126e5e8"
   integrity sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==
   dependencies:
     "@posthog/types" "^1.392.0"
 
-"@posthog/types@^1.391.1", "@posthog/types@^1.392.0", "@posthog/types@^1.392.1":
+"@posthog/types@^1.392.0", "@posthog/types@^1.392.1":
   version "1.392.1"
   resolved "https://registry.yarnpkg.com/@posthog/types/-/types-1.392.1.tgz#f0d0df161ba5903ee479a1c2253c69f444df3aa0"
   integrity sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==
@@ -972,7 +972,7 @@ cookie@~0.7.1, cookie@~0.7.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
-core-js@^3.38.1, core-js@^3.49.0:
+core-js@^3.49.0:
   version "3.49.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.49.0.tgz#8b4d520ac034311fa21aa616f017ada0e0dbbddd"
   integrity sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==
@@ -2307,20 +2307,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-posthog-js@1.395.0:
-  version "1.395.0"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.395.0.tgz#859835101191f980796be0353fa4416e0aa5406b"
-  integrity sha512-5iTb00CGt2eQUUiBQysQiX89RAbCN6wK2sDNzvs9zv0alaY8mJ0ZySrUD3LQ+XyLhgM5pCpacBuUwChqiYDLDw==
-  dependencies:
-    "@posthog/core" "^1.38.0"
-    "@posthog/types" "^1.391.1"
-    core-js "^3.38.1"
-    dompurify "^3.3.2"
-    fflate "^0.4.8"
-    preact "^10.29.2"
-    query-selector-shadow-dom "^1.0.1"
-    web-vitals "^5.3.0"
-
 posthog-js@1.398.7:
   version "1.398.7"
   resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.398.7.tgz#a46db749f0d31c17768686d8b7b7357a902cd833"
@@ -2334,11 +2320,6 @@ posthog-js@1.398.7:
     preact "^10.29.3"
     query-selector-shadow-dom "^1.0.1"
     web-vitals "^5.3.0"
-
-preact@^10.29.2:
-  version "10.29.4"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.29.4.tgz#186cd3ce0fea34e5d1930881238c16e1fb902253"
-  integrity sha512-GMpwh9+NJ8tSmqwIaVyFRQkiKfBEzQ+k7r7tle4W+kaJ+7wJiB9hFz9BixAomMtenPPSBfM4bZhXozGxhf0uFQ==
 
 preact@^10.29.3:
   version "10.29.7"


### PR DESCRIPTION
## Problem

The first release run failed at `:kotlinStoreYarnLock` (`Lock file was changed`): https://github.com/PostHog/posthog-kmp/actions/runs/29347480941/job/87134960739

The committed `kotlin-js-store/yarn.lock` was stale — it still carried dependency ranges (`@posthog/core@^1.38.0`, `@posthog/types@^1.391.1`, `core-js@^3.38.1`) that nothing requests anymore. It slipped through because CI's JS job only runs `:posthog-kmp:compileKotlinJs`, which never validates the lock; the release workflow's full `./gradlew build` was the first job to check it. Reproduced on unmodified `main` — the release's version bump was not the trigger.

## Changes

- Regenerate `kotlin-js-store/yarn.lock` via `kotlinUpgradeYarnLock` (verified `kotlinStoreYarnLock` passes at both 0.0.0 and a bumped 0.0.1).
- CI's JS Build job now also runs `kotlinStoreYarnLock`, so a stale lock fails the PR instead of the release.

The 0.0.1 changeset is still on `main` (the release failed before consuming it), so once this merges the release can be retried via `workflow_dispatch`. No changeset: CI/lockfile only.

- New `Release Dry Run` CI job (ubuntu, every PR — same pattern as posthog-rs's "Cargo publish dry run" and posthog-android's full compile): version bump → `build` → `allTests` → `publishToMavenLocal`, mirroring the release without credentials or side effects. iOS stays covered by the existing macOS job.
