### PR TITLE
feat: add JVM (desktop) target backed by the posthog core library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,26 @@ jobs:
       - name: Run unit tests and build Android sample
         run: ./gradlew :posthog-kmp:testAndroid :sample:androidApp:assembleDebug --no-daemon
 
+  jvm:
+    name: JVM Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+
+      - name: Run JVM tests
+        run: ./gradlew :posthog-kmp:jvmTest --no-daemon
+
   js:
     name: JS Build
     runs-on: ubuntu-latest

--- a/.sampo/changesets/jvm-target.md
+++ b/.sampo/changesets/jvm-target.md
@@ -1,0 +1,5 @@
+---
+posthog-kmp: minor
+---
+
+Add a JVM (desktop) target backed by `com.posthog:posthog`, the pure-JVM core library the Android SDK is built on. Event capture, identification, feature flags, groups, error tracking and super properties are fully supported; the offline event queue and identity cache persist under `~/.posthog-kmp`. Mobile/browser-only options (session recording, lifecycle events, screen-view autocapture, deep links) are ignored on the JVM.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Kotlin](https://img.shields.io/badge/kotlin-2.3.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A **Kotlin Multiplatform** SDK for [PostHog](https://posthog.com) analytics, supporting Android, iOS, Web (JS).
+A **Kotlin Multiplatform** SDK for [PostHog](https://posthog.com) analytics, supporting Android, iOS, Web (JS), and JVM (desktop).
 
 ## Features
 
@@ -26,6 +26,7 @@ A **Kotlin Multiplatform** SDK for [PostHog](https://posthog.com) analytics, sup
 | Android | ✅ | PostHog Android SDK (native) |
 | iOS | ✅ | PostHog iOS SDK (native via SPM) |
 | JS (Browser) | ✅ | posthog-js (native) |
+| JVM (Desktop) | ✅ | PostHog core library (`com.posthog:posthog`) |
 
 ## Installation
 
@@ -108,7 +109,7 @@ class MainActivity : ComponentActivity() {
 }
 ```
 
-#### iOS / Web
+#### iOS / Web / JVM (Desktop)
 
 On non-Android platforms, use the no-argument `PostHogContext()`:
 
@@ -132,7 +133,19 @@ fun main() {
     )
     // ...
 }
+
+// Desktop (Compose Multiplatform) main.kt
+fun main() = application {
+    PostHog.setup(
+        config = PostHogConfig(apiKey = "phc_your_api_key"),
+        context = PostHogContext()
+    )
+    Window(onCloseRequest = ::exitApplication) { App() }
+}
 ```
+
+On the JVM, the SDK persists its offline event queue and identity cache under
+`~/.posthog-kmp`.
 
 ### Capture Events
 
@@ -431,6 +444,13 @@ PostHog.close()
 - Session recording available
 - LocalStorage persistence
 - Autocapture support
+
+### JVM (Desktop)
+- Wraps `com.posthog:posthog`, the pure-JVM core library the Android SDK is built on
+- Event capture, identification, feature flags, groups, error tracking and super properties all supported
+- Offline event queue and identity persisted to disk under `~/.posthog-kmp`
+- No session recording, lifecycle events, screen-view autocapture or deep links (mobile/browser-only concepts); those config options are ignored
+- Useful for Compose Multiplatform desktop apps, including during development with Compose Hot Reload
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -448,8 +448,9 @@ PostHog.close()
 ### JVM (Desktop)
 - Wraps `com.posthog:posthog`, the pure-JVM core library the Android SDK is built on
 - Event capture, identification, feature flags, groups, error tracking and super properties all supported
-- Offline event queue and identity persisted to disk under `~/.posthog-kmp`
+- Offline event queue and identity persisted to disk under `~/.posthog-kmp` (falls back to the temp dir with a warning when `user.home` is unset, e.g. some containers)
 - No session recording, lifecycle events, screen-view autocapture or deep links (mobile/browser-only concepts); those config options are ignored
+- No `$app_version`/`$app_build`/`$app_namespace` person properties (the JVM has no standard app-manifest source) — feature flags targeting those won't match desktop users
 - Useful for Compose Multiplatform desktop apps, including during development with Compose Hot Reload
 
 ## Contributing

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -8,14 +8,14 @@
     <ID>LongMethod:App.kt$@Composable fun App(postHogContext: PostHogContext)</ID>
     <ID>LoopWithTooManyJumpStatements:PostHog.ios.kt$for</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val androidMain by getting { dependencies { implementation(libs.androidx.activity.compose) } }</ID>
-    <ID>UnusedPrivateProperty:build.gradle.kts$val androidMain by getting { dependencies { implementation(libs.posthog.android) } }</ID>
+    <ID>UnusedPrivateProperty:build.gradle.kts$val androidMain by getting { dependsOn(jvmCommonMain) dependencies { implementation(libs.posthog.android) } }</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val commonTest by getting { dependencies { implementation(libs.kotlin.test) } }</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val iosArm64Main by getting { dependsOn(iosMain) }</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val iosSimulatorArm64Main by getting { dependsOn(iosMain) }</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val iosX64Main by getting { dependsOn(iosMain) }</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val jsMain by getting { dependencies { implementation(npm("posthog-js", libs.versions.posthog.js.get())) } }</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val jsMain by getting { dependsOn(commonMain) }</ID>
-    <ID>UnusedPrivateProperty:build.gradle.kts$val jvmMain by getting { dependencies { implementation(libs.posthog.core) } }</ID>
+    <ID>UnusedPrivateProperty:build.gradle.kts$val jvmMain by getting { dependsOn(jvmCommonMain) }</ID>
     <ID>UseCheckOrError:PostHogContext.android.kt$throw IllegalStateException( "Android requires Application context. Use PostHogContext(application) instead." )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -15,6 +15,7 @@
     <ID>UnusedPrivateProperty:build.gradle.kts$val iosX64Main by getting { dependsOn(iosMain) }</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val jsMain by getting { dependencies { implementation(npm("posthog-js", libs.versions.posthog.js.get())) } }</ID>
     <ID>UnusedPrivateProperty:build.gradle.kts$val jsMain by getting { dependsOn(commonMain) }</ID>
+    <ID>UnusedPrivateProperty:build.gradle.kts$val jvmMain by getting { dependencies { implementation(libs.posthog.core) } }</ID>
     <ID>UseCheckOrError:PostHogContext.android.kt$throw IllegalStateException( "Android requires Application context. Use PostHogContext(application) instead." )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ android-compileSdk = "36"
 compose-multiplatform = "1.10.0"
 androidx-activity-compose = "1.12.3"
 posthog-android = "3.53.3"
+# Pure-JVM core that posthog-android is built on (versioned independently of posthog-android)
+posthog-core = "6.24.0"
 posthog-ios = "3.64.1"
 posthog-js = "1.398.7"
 mavenPublish = "0.35.0"
@@ -23,6 +25,7 @@ kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", versio
 
 # PostHog SDKs
 posthog-android = { group = "com.posthog", name = "posthog-android", version.ref = "posthog-android" }
+posthog-core = { group = "com.posthog", name = "posthog", version.ref = "posthog-core" }
 
 
 # Testing

--- a/posthog-kmp/build.gradle.kts
+++ b/posthog-kmp/build.gradle.kts
@@ -91,6 +91,12 @@ kotlin {
         binaries.library()
     }
 
+    jvm {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+
     sourceSets {
         val commonMain by getting {
             kotlin.srcDir(generatedVersionDir)
@@ -119,6 +125,12 @@ kotlin {
         val jsMain by getting {
             dependencies {
                 implementation(npm("posthog-js", libs.versions.posthog.js.get()))
+            }
+        }
+
+        val jvmMain by getting {
+            dependencies {
+                implementation(libs.posthog.core)
             }
         }
     }

--- a/posthog-kmp/build.gradle.kts
+++ b/posthog-kmp/build.gradle.kts
@@ -108,7 +108,16 @@ kotlin {
             }
         }
 
+        // shared delegation to the core PostHogInterface for the two JVM-backed targets
+        val jvmCommonMain by creating {
+            dependsOn(commonMain)
+            dependencies {
+                implementation(libs.posthog.core)
+            }
+        }
+
         val androidMain by getting {
+            dependsOn(jvmCommonMain)
             dependencies {
                 implementation(libs.posthog.android)
             }
@@ -129,9 +138,7 @@ kotlin {
         }
 
         val jvmMain by getting {
-            dependencies {
-                implementation(libs.posthog.core)
-            }
+            dependsOn(jvmCommonMain)
         }
     }
 }

--- a/posthog-kmp/src/androidMain/kotlin/com/posthog/kmp/PostHog.android.kt
+++ b/posthog-kmp/src/androidMain/kotlin/com/posthog/kmp/PostHog.android.kt
@@ -1,15 +1,8 @@
 package com.posthog.kmp
 
-import com.posthog.PostHogInterface
 import com.posthog.android.PostHogAndroid
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.replay.PostHogSessionReplayConfig
-import java.util.Date
-
-@Volatile
-internal var postHogInstance: PostHogInterface? = null
-
-private const val SDK_NAME = "posthog-kmp"
 
 internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext) {
     val androidConfig = PostHogAndroidConfig(
@@ -33,7 +26,7 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
 
         optOut = config.optOut
 
-        personProfiles = config.personProfiles.toAndroidPersonProfiles()
+        personProfiles = config.personProfiles.toCorePersonProfiles()
 
         config.sessionRecording?.let { sessionConfig ->
             sessionReplay = sessionConfig.enabled
@@ -48,162 +41,4 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
     }
 
     postHogInstance = PostHogAndroid.with(context.application, androidConfig)
-}
-
-internal actual fun platformCapture(
-    event: String,
-    properties: Map<String, Any>?,
-    groups: Map<String, String>?,
-    timestamp: Long?
-) {
-    postHogInstance?.capture(
-        event = event,
-        properties = properties,
-        groups = groups,
-        timestamp = timestamp?.let { Date(it) }
-    )
-}
-
-internal actual fun platformScreen(screenName: String, properties: Map<String, Any>?) {
-    postHogInstance?.screen(
-        screenTitle = screenName,
-        properties = properties
-    )
-}
-
-internal actual fun platformIdentify(
-    distinctId: String,
-    userProperties: Map<String, Any>?,
-    userPropertiesSetOnce: Map<String, Any>?
-) {
-    postHogInstance?.identify(
-        distinctId = distinctId,
-        userProperties = userProperties,
-        userPropertiesSetOnce = userPropertiesSetOnce
-    )
-}
-
-internal actual fun platformAlias(alias: String) {
-    postHogInstance?.alias(alias)
-}
-
-internal actual fun platformReset() {
-    postHogInstance?.reset()
-}
-
-internal actual fun platformGetDistinctId(): String? {
-    return postHogInstance?.distinctId()
-}
-
-internal actual fun platformRegister(key: String, value: Any) {
-    postHogInstance?.register(key, value)
-}
-
-internal actual fun platformUnregister(key: String) {
-    postHogInstance?.unregister(key)
-}
-
-internal actual fun platformGroup(
-    type: String,
-    key: String,
-    groupProperties: Map<String, Any>?
-) {
-    postHogInstance?.group(
-        type = type,
-        key = key,
-        groupProperties = groupProperties
-    )
-}
-
-internal actual fun platformIsFeatureEnabled(key: String, defaultValue: Boolean, sendFeatureFlagEvent: Boolean): Boolean {
-    return postHogInstance?.isFeatureEnabled(key, defaultValue, sendFeatureFlagEvent) ?: defaultValue
-}
-
-internal actual fun platformGetFeatureFlag(key: String, sendFeatureFlagEvent: Boolean): Any? {
-    return postHogInstance?.getFeatureFlag(key, sendFeatureFlagEvent = sendFeatureFlagEvent)
-}
-
-internal actual fun platformGetAllFeatureFlags(): Map<String, FeatureFlagResult> {
-    return postHogInstance?.getAllFeatureFlags()?.associate {
-        it.key to it.toFeatureFlagResult()
-    } ?: emptyMap()
-}
-
-internal actual fun platformReloadFeatureFlags(callback: (() -> Unit)?) {
-    if (callback != null) {
-        postHogInstance?.reloadFeatureFlags { callback() }
-    } else {
-        postHogInstance?.reloadFeatureFlags()
-    }
-}
-
-internal actual fun platformGetFeatureFlagResult(key: String, sendFeatureFlagEvent: Boolean): FeatureFlagResult? {
-    return postHogInstance?.getFeatureFlagResult(key, sendFeatureFlagEvent)?.toFeatureFlagResult()
-}
-
-internal actual fun platformCaptureException(
-    throwable: Throwable,
-    additionalProperties: Map<String, Any>?
-) {
-    postHogInstance?.captureException(
-        throwable = throwable,
-        properties = additionalProperties
-    )
-}
-
-internal actual fun platformGetAnonymousId(): String? {
-    return postHogInstance?.getAnonymousId()
-}
-
-internal actual fun platformGetSessionId(): String? {
-    return postHogInstance?.getSessionId()?.toString()
-}
-
-internal actual fun platformOptOut() {
-    postHogInstance?.optOut()
-}
-
-internal actual fun platformOptIn() {
-    postHogInstance?.optIn()
-}
-
-internal actual fun platformIsOptedOut(): Boolean {
-    return postHogInstance?.isOptOut() ?: false
-}
-
-internal actual fun platformFlush() {
-    postHogInstance?.flush()
-}
-
-internal actual fun platformClose() {
-    postHogInstance?.close()
-    postHogInstance = null
-}
-
-internal actual fun platformSetDebug(enabled: Boolean) {
-    postHogInstance?.debug(enabled)
-}
-
-internal actual fun platformSetPersonProperties(
-    userProperties: Map<String, Any>?,
-    userPropertiesSetOnce: Map<String, Any>?
-) {
-    postHogInstance?.setPersonProperties(userProperties, userPropertiesSetOnce)
-}
-
-private fun PersonProfiles.toAndroidPersonProfiles(): com.posthog.PersonProfiles {
-    return when (this) {
-        PersonProfiles.ALWAYS -> com.posthog.PersonProfiles.ALWAYS
-        PersonProfiles.IDENTIFIED_ONLY -> com.posthog.PersonProfiles.IDENTIFIED_ONLY
-        PersonProfiles.NEVER -> com.posthog.PersonProfiles.NEVER
-    }
-}
-
-private fun com.posthog.FeatureFlagResult.toFeatureFlagResult(): FeatureFlagResult {
-    return FeatureFlagResult(
-        key = key,
-        enabled = enabled,
-        variant = variant,
-        payload = payload
-    )
 }

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -1,0 +1,167 @@
+package com.posthog.kmp
+
+import com.posthog.PostHogInterface
+import java.util.Date
+
+@Volatile
+internal var postHogInstance: PostHogInterface? = null
+
+internal const val SDK_NAME = "posthog-kmp"
+
+internal actual fun platformCapture(
+    event: String,
+    properties: Map<String, Any>?,
+    groups: Map<String, String>?,
+    timestamp: Long?
+) {
+    postHogInstance?.capture(
+        event = event,
+        properties = properties,
+        groups = groups,
+        timestamp = timestamp?.let { Date(it) }
+    )
+}
+
+internal actual fun platformScreen(screenName: String, properties: Map<String, Any>?) {
+    postHogInstance?.screen(
+        screenTitle = screenName,
+        properties = properties
+    )
+}
+
+internal actual fun platformIdentify(
+    distinctId: String,
+    userProperties: Map<String, Any>?,
+    userPropertiesSetOnce: Map<String, Any>?
+) {
+    postHogInstance?.identify(
+        distinctId = distinctId,
+        userProperties = userProperties,
+        userPropertiesSetOnce = userPropertiesSetOnce
+    )
+}
+
+internal actual fun platformAlias(alias: String) {
+    postHogInstance?.alias(alias)
+}
+
+internal actual fun platformReset() {
+    postHogInstance?.reset()
+}
+
+internal actual fun platformGetDistinctId(): String? {
+    return postHogInstance?.distinctId()
+}
+
+internal actual fun platformRegister(key: String, value: Any) {
+    postHogInstance?.register(key, value)
+}
+
+internal actual fun platformUnregister(key: String) {
+    postHogInstance?.unregister(key)
+}
+
+internal actual fun platformGroup(
+    type: String,
+    key: String,
+    groupProperties: Map<String, Any>?
+) {
+    postHogInstance?.group(
+        type = type,
+        key = key,
+        groupProperties = groupProperties
+    )
+}
+
+internal actual fun platformIsFeatureEnabled(key: String, defaultValue: Boolean, sendFeatureFlagEvent: Boolean): Boolean {
+    return postHogInstance?.isFeatureEnabled(key, defaultValue, sendFeatureFlagEvent) ?: defaultValue
+}
+
+internal actual fun platformGetFeatureFlag(key: String, sendFeatureFlagEvent: Boolean): Any? {
+    return postHogInstance?.getFeatureFlag(key, sendFeatureFlagEvent = sendFeatureFlagEvent)
+}
+
+internal actual fun platformGetAllFeatureFlags(): Map<String, FeatureFlagResult> {
+    return postHogInstance?.getAllFeatureFlags()?.associate {
+        it.key to it.toFeatureFlagResult()
+    } ?: emptyMap()
+}
+
+internal actual fun platformReloadFeatureFlags(callback: (() -> Unit)?) {
+    if (callback != null) {
+        postHogInstance?.reloadFeatureFlags { callback() }
+    } else {
+        postHogInstance?.reloadFeatureFlags()
+    }
+}
+
+internal actual fun platformGetFeatureFlagResult(key: String, sendFeatureFlagEvent: Boolean): FeatureFlagResult? {
+    return postHogInstance?.getFeatureFlagResult(key, sendFeatureFlagEvent)?.toFeatureFlagResult()
+}
+
+internal actual fun platformCaptureException(
+    throwable: Throwable,
+    additionalProperties: Map<String, Any>?
+) {
+    postHogInstance?.captureException(
+        throwable = throwable,
+        properties = additionalProperties
+    )
+}
+
+internal actual fun platformGetAnonymousId(): String? {
+    return postHogInstance?.getAnonymousId()
+}
+
+internal actual fun platformGetSessionId(): String? {
+    return postHogInstance?.getSessionId()?.toString()
+}
+
+internal actual fun platformOptOut() {
+    postHogInstance?.optOut()
+}
+
+internal actual fun platformOptIn() {
+    postHogInstance?.optIn()
+}
+
+internal actual fun platformIsOptedOut(): Boolean {
+    return postHogInstance?.isOptOut() ?: false
+}
+
+internal actual fun platformFlush() {
+    postHogInstance?.flush()
+}
+
+internal actual fun platformClose() {
+    postHogInstance?.close()
+    postHogInstance = null
+}
+
+internal actual fun platformSetDebug(enabled: Boolean) {
+    postHogInstance?.debug(enabled)
+}
+
+internal actual fun platformSetPersonProperties(
+    userProperties: Map<String, Any>?,
+    userPropertiesSetOnce: Map<String, Any>?
+) {
+    postHogInstance?.setPersonProperties(userProperties, userPropertiesSetOnce)
+}
+
+internal fun PersonProfiles.toCorePersonProfiles(): com.posthog.PersonProfiles {
+    return when (this) {
+        PersonProfiles.ALWAYS -> com.posthog.PersonProfiles.ALWAYS
+        PersonProfiles.IDENTIFIED_ONLY -> com.posthog.PersonProfiles.IDENTIFIED_ONLY
+        PersonProfiles.NEVER -> com.posthog.PersonProfiles.NEVER
+    }
+}
+
+internal fun com.posthog.FeatureFlagResult.toFeatureFlagResult(): FeatureFlagResult {
+    return FeatureFlagResult(
+        key = key,
+        enabled = enabled,
+        variant = variant,
+        payload = payload
+    )
+}

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHog.jvm.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHog.jvm.kt
@@ -1,13 +1,6 @@
 package com.posthog.kmp
 
-import com.posthog.PostHogInterface
 import java.io.File
-import java.util.Date
-
-@Volatile
-internal var postHogInstance: PostHogInterface? = null
-
-private const val SDK_NAME = "posthog-kmp"
 
 /**
  * JVM (desktop) implementation backed by `com.posthog:posthog`, the pure-JVM core library
@@ -38,10 +31,11 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
 
         optOut = config.optOut
 
-        personProfiles = config.personProfiles.toJvmPersonProfiles()
+        personProfiles = config.personProfiles.toCorePersonProfiles()
     }
 
-    val storageDir = defaultStorageDir()
+    val home = System.getProperty("user.home")?.takeIf { it.isNotBlank() }
+    val storageDir = File(home ?: System.getProperty("java.io.tmpdir") ?: ".", ".posthog-kmp")
     // the disk queue namespaces by API key itself; the preferences file doesn't
     coreConfig.storagePrefix = File(storageDir, "queue").absolutePath
     coreConfig.cachePreferences = PostHogFilePreferences(
@@ -51,168 +45,12 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
     coreConfig.context = PostHogJvmContext(coreConfig)
 
     postHogInstance = com.posthog.PostHog.with(coreConfig)
-}
 
-private fun defaultStorageDir(): File {
-    val home = System.getProperty("user.home")?.takeIf { it.isNotBlank() }
-    val base = home ?: System.getProperty("java.io.tmpdir") ?: "."
-    return File(base, ".posthog-kmp")
-}
-
-internal actual fun platformCapture(
-    event: String,
-    properties: Map<String, Any>?,
-    groups: Map<String, String>?,
-    timestamp: Long?
-) {
-    postHogInstance?.capture(
-        event = event,
-        properties = properties,
-        groups = groups,
-        timestamp = timestamp?.let { Date(it) }
-    )
-}
-
-internal actual fun platformScreen(screenName: String, properties: Map<String, Any>?) {
-    postHogInstance?.screen(
-        screenTitle = screenName,
-        properties = properties
-    )
-}
-
-internal actual fun platformIdentify(
-    distinctId: String,
-    userProperties: Map<String, Any>?,
-    userPropertiesSetOnce: Map<String, Any>?
-) {
-    postHogInstance?.identify(
-        distinctId = distinctId,
-        userProperties = userProperties,
-        userPropertiesSetOnce = userPropertiesSetOnce
-    )
-}
-
-internal actual fun platformAlias(alias: String) {
-    postHogInstance?.alias(alias)
-}
-
-internal actual fun platformReset() {
-    postHogInstance?.reset()
-}
-
-internal actual fun platformGetDistinctId(): String? {
-    return postHogInstance?.distinctId()
-}
-
-internal actual fun platformRegister(key: String, value: Any) {
-    postHogInstance?.register(key, value)
-}
-
-internal actual fun platformUnregister(key: String) {
-    postHogInstance?.unregister(key)
-}
-
-internal actual fun platformGroup(
-    type: String,
-    key: String,
-    groupProperties: Map<String, Any>?
-) {
-    postHogInstance?.group(
-        type = type,
-        key = key,
-        groupProperties = groupProperties
-    )
-}
-
-internal actual fun platformIsFeatureEnabled(key: String, defaultValue: Boolean, sendFeatureFlagEvent: Boolean): Boolean {
-    return postHogInstance?.isFeatureEnabled(key, defaultValue, sendFeatureFlagEvent) ?: defaultValue
-}
-
-internal actual fun platformGetFeatureFlag(key: String, sendFeatureFlagEvent: Boolean): Any? {
-    return postHogInstance?.getFeatureFlag(key, sendFeatureFlagEvent = sendFeatureFlagEvent)
-}
-
-internal actual fun platformGetAllFeatureFlags(): Map<String, FeatureFlagResult> {
-    return postHogInstance?.getAllFeatureFlags()?.associate {
-        it.key to it.toFeatureFlagResult()
-    } ?: emptyMap()
-}
-
-internal actual fun platformReloadFeatureFlags(callback: (() -> Unit)?) {
-    if (callback != null) {
-        postHogInstance?.reloadFeatureFlags { callback() }
-    } else {
-        postHogInstance?.reloadFeatureFlags()
+    // the real logger is only installed during setup above; before that it is a no-op
+    if (home == null) {
+        coreConfig.logger.log(
+            "user.home is not set; PostHog is storing its event queue and identity cache under " +
+                "${storageDir.absolutePath}, which may not survive restarts."
+        )
     }
-}
-
-internal actual fun platformGetFeatureFlagResult(key: String, sendFeatureFlagEvent: Boolean): FeatureFlagResult? {
-    return postHogInstance?.getFeatureFlagResult(key, sendFeatureFlagEvent)?.toFeatureFlagResult()
-}
-
-internal actual fun platformCaptureException(
-    throwable: Throwable,
-    additionalProperties: Map<String, Any>?
-) {
-    postHogInstance?.captureException(
-        throwable = throwable,
-        properties = additionalProperties
-    )
-}
-
-internal actual fun platformGetAnonymousId(): String? {
-    return postHogInstance?.getAnonymousId()
-}
-
-internal actual fun platformGetSessionId(): String? {
-    return postHogInstance?.getSessionId()?.toString()
-}
-
-internal actual fun platformOptOut() {
-    postHogInstance?.optOut()
-}
-
-internal actual fun platformOptIn() {
-    postHogInstance?.optIn()
-}
-
-internal actual fun platformIsOptedOut(): Boolean {
-    return postHogInstance?.isOptOut() ?: false
-}
-
-internal actual fun platformFlush() {
-    postHogInstance?.flush()
-}
-
-internal actual fun platformClose() {
-    postHogInstance?.close()
-    postHogInstance = null
-}
-
-internal actual fun platformSetDebug(enabled: Boolean) {
-    postHogInstance?.debug(enabled)
-}
-
-internal actual fun platformSetPersonProperties(
-    userProperties: Map<String, Any>?,
-    userPropertiesSetOnce: Map<String, Any>?
-) {
-    postHogInstance?.setPersonProperties(userProperties, userPropertiesSetOnce)
-}
-
-private fun PersonProfiles.toJvmPersonProfiles(): com.posthog.PersonProfiles {
-    return when (this) {
-        PersonProfiles.ALWAYS -> com.posthog.PersonProfiles.ALWAYS
-        PersonProfiles.IDENTIFIED_ONLY -> com.posthog.PersonProfiles.IDENTIFIED_ONLY
-        PersonProfiles.NEVER -> com.posthog.PersonProfiles.NEVER
-    }
-}
-
-private fun com.posthog.FeatureFlagResult.toFeatureFlagResult(): FeatureFlagResult {
-    return FeatureFlagResult(
-        key = key,
-        enabled = enabled,
-        variant = variant,
-        payload = payload
-    )
 }

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHog.jvm.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHog.jvm.kt
@@ -1,0 +1,218 @@
+package com.posthog.kmp
+
+import com.posthog.PostHogInterface
+import java.io.File
+import java.util.Date
+
+@Volatile
+internal var postHogInstance: PostHogInterface? = null
+
+private const val SDK_NAME = "posthog-kmp"
+
+/**
+ * JVM (desktop) implementation backed by `com.posthog:posthog`, the pure-JVM core library
+ * the Android SDK is built on.
+ *
+ * Android/iOS-only config options are ignored here:
+ * [PostHogConfig.captureApplicationLifecycleEvents], [PostHogConfig.captureScreenViews],
+ * [PostHogConfig.captureDeepLinks], [PostHogConfig.sessionRecording] and
+ * [PostHogConfig.autocapture].
+ */
+@Suppress("UNUSED_PARAMETER")
+internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext) {
+    val coreConfig = com.posthog.PostHogConfig(
+        apiKey = config.apiKey,
+        host = config.host
+    ).apply {
+        sdkName = SDK_NAME
+        sdkVersion = PostHogKmpVersion.VERSION
+
+        debug = config.debug
+        sendFeatureFlagEvent = config.sendFeatureFlagEvent
+        preloadFeatureFlags = config.preloadFeatureFlags
+
+        flushAt = config.flushAt
+        flushIntervalSeconds = config.flushIntervalSeconds
+        maxQueueSize = config.maxQueueSize
+        maxBatchSize = config.maxBatchSize
+
+        optOut = config.optOut
+
+        personProfiles = config.personProfiles.toJvmPersonProfiles()
+    }
+
+    val storageDir = defaultStorageDir()
+    // the disk queue namespaces by API key itself; the preferences file doesn't
+    coreConfig.storagePrefix = File(storageDir, "queue").absolutePath
+    coreConfig.cachePreferences = PostHogFilePreferences(
+        File(storageDir, "posthog-prefs-${coreConfig.apiKey}.json"),
+        coreConfig
+    )
+    coreConfig.context = PostHogJvmContext(coreConfig)
+
+    postHogInstance = com.posthog.PostHog.with(coreConfig)
+}
+
+private fun defaultStorageDir(): File {
+    val home = System.getProperty("user.home")?.takeIf { it.isNotBlank() }
+    val base = home ?: System.getProperty("java.io.tmpdir") ?: "."
+    return File(base, ".posthog-kmp")
+}
+
+internal actual fun platformCapture(
+    event: String,
+    properties: Map<String, Any>?,
+    groups: Map<String, String>?,
+    timestamp: Long?
+) {
+    postHogInstance?.capture(
+        event = event,
+        properties = properties,
+        groups = groups,
+        timestamp = timestamp?.let { Date(it) }
+    )
+}
+
+internal actual fun platformScreen(screenName: String, properties: Map<String, Any>?) {
+    postHogInstance?.screen(
+        screenTitle = screenName,
+        properties = properties
+    )
+}
+
+internal actual fun platformIdentify(
+    distinctId: String,
+    userProperties: Map<String, Any>?,
+    userPropertiesSetOnce: Map<String, Any>?
+) {
+    postHogInstance?.identify(
+        distinctId = distinctId,
+        userProperties = userProperties,
+        userPropertiesSetOnce = userPropertiesSetOnce
+    )
+}
+
+internal actual fun platformAlias(alias: String) {
+    postHogInstance?.alias(alias)
+}
+
+internal actual fun platformReset() {
+    postHogInstance?.reset()
+}
+
+internal actual fun platformGetDistinctId(): String? {
+    return postHogInstance?.distinctId()
+}
+
+internal actual fun platformRegister(key: String, value: Any) {
+    postHogInstance?.register(key, value)
+}
+
+internal actual fun platformUnregister(key: String) {
+    postHogInstance?.unregister(key)
+}
+
+internal actual fun platformGroup(
+    type: String,
+    key: String,
+    groupProperties: Map<String, Any>?
+) {
+    postHogInstance?.group(
+        type = type,
+        key = key,
+        groupProperties = groupProperties
+    )
+}
+
+internal actual fun platformIsFeatureEnabled(key: String, defaultValue: Boolean, sendFeatureFlagEvent: Boolean): Boolean {
+    return postHogInstance?.isFeatureEnabled(key, defaultValue, sendFeatureFlagEvent) ?: defaultValue
+}
+
+internal actual fun platformGetFeatureFlag(key: String, sendFeatureFlagEvent: Boolean): Any? {
+    return postHogInstance?.getFeatureFlag(key, sendFeatureFlagEvent = sendFeatureFlagEvent)
+}
+
+internal actual fun platformGetAllFeatureFlags(): Map<String, FeatureFlagResult> {
+    return postHogInstance?.getAllFeatureFlags()?.associate {
+        it.key to it.toFeatureFlagResult()
+    } ?: emptyMap()
+}
+
+internal actual fun platformReloadFeatureFlags(callback: (() -> Unit)?) {
+    if (callback != null) {
+        postHogInstance?.reloadFeatureFlags { callback() }
+    } else {
+        postHogInstance?.reloadFeatureFlags()
+    }
+}
+
+internal actual fun platformGetFeatureFlagResult(key: String, sendFeatureFlagEvent: Boolean): FeatureFlagResult? {
+    return postHogInstance?.getFeatureFlagResult(key, sendFeatureFlagEvent)?.toFeatureFlagResult()
+}
+
+internal actual fun platformCaptureException(
+    throwable: Throwable,
+    additionalProperties: Map<String, Any>?
+) {
+    postHogInstance?.captureException(
+        throwable = throwable,
+        properties = additionalProperties
+    )
+}
+
+internal actual fun platformGetAnonymousId(): String? {
+    return postHogInstance?.getAnonymousId()
+}
+
+internal actual fun platformGetSessionId(): String? {
+    return postHogInstance?.getSessionId()?.toString()
+}
+
+internal actual fun platformOptOut() {
+    postHogInstance?.optOut()
+}
+
+internal actual fun platformOptIn() {
+    postHogInstance?.optIn()
+}
+
+internal actual fun platformIsOptedOut(): Boolean {
+    return postHogInstance?.isOptOut() ?: false
+}
+
+internal actual fun platformFlush() {
+    postHogInstance?.flush()
+}
+
+internal actual fun platformClose() {
+    postHogInstance?.close()
+    postHogInstance = null
+}
+
+internal actual fun platformSetDebug(enabled: Boolean) {
+    postHogInstance?.debug(enabled)
+}
+
+internal actual fun platformSetPersonProperties(
+    userProperties: Map<String, Any>?,
+    userPropertiesSetOnce: Map<String, Any>?
+) {
+    postHogInstance?.setPersonProperties(userProperties, userPropertiesSetOnce)
+}
+
+private fun PersonProfiles.toJvmPersonProfiles(): com.posthog.PersonProfiles {
+    return when (this) {
+        PersonProfiles.ALWAYS -> com.posthog.PersonProfiles.ALWAYS
+        PersonProfiles.IDENTIFIED_ONLY -> com.posthog.PersonProfiles.IDENTIFIED_ONLY
+        PersonProfiles.NEVER -> com.posthog.PersonProfiles.NEVER
+    }
+}
+
+private fun com.posthog.FeatureFlagResult.toFeatureFlagResult(): FeatureFlagResult {
+    return FeatureFlagResult(
+        key = key,
+        enabled = enabled,
+        variant = variant,
+        payload = payload
+    )
+}

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogContext.jvm.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogContext.jvm.kt
@@ -1,0 +1,14 @@
+package com.posthog.kmp
+
+/**
+ * JVM (desktop/server) PostHog context.
+ * No platform-specific context is required for the JVM.
+ */
+public actual class PostHogContext internal constructor(
+    @Suppress("unused") private val unit: Unit = Unit
+)
+
+/**
+ * Creates a PostHogContext for the JVM.
+ */
+public actual fun PostHogContext(): PostHogContext = PostHogContext(Unit)

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogFilePreferences.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogFilePreferences.kt
@@ -6,17 +6,25 @@ import java.io.File
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.util.concurrent.Executors
 
 /**
  * File-backed [PostHogPreferences] so identity, opt-out state and cached feature flags
  * survive process restarts. The store is a single JSON object; writes go to a temp file
  * and are moved over the previous one so a crash mid-write cannot corrupt the store.
+ *
+ * Disk writes run on a dedicated daemon thread so callers (and readers, which share the
+ * lock) never block on I/O — the same durability tradeoff as SharedPreferences.apply()
+ * on Android: a hard kill can lose the last write.
  */
 internal class PostHogFilePreferences(
     private val file: File,
     private val config: com.posthog.PostHogConfig,
 ) : PostHogPreferences {
     private val lock = Any()
+    private val executor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "PostHogFilePreferences").apply { isDaemon = true }
+    }
     private val preferences: MutableMap<String, Any> by lazy { load() }
 
     override fun getValue(key: String, defaultValue: Any?): Any? {
@@ -28,8 +36,8 @@ internal class PostHogFilePreferences(
     override fun setValue(key: String, value: Any) {
         synchronized(lock) {
             preferences[key] = value
-            persist()
         }
+        schedulePersist()
     }
 
     override fun clear(except: List<String>) {
@@ -40,15 +48,15 @@ internal class PostHogFilePreferences(
                     it.remove()
                 }
             }
-            persist()
         }
+        schedulePersist()
     }
 
     override fun remove(key: String) {
         synchronized(lock) {
             preferences.remove(key)
-            persist()
         }
+        schedulePersist()
     }
 
     override fun getAll(): Map<String, Any> {
@@ -59,6 +67,10 @@ internal class PostHogFilePreferences(
         return props.filterKeys { key ->
             !ALL_INTERNAL_KEYS.contains(key)
         }
+    }
+
+    internal fun awaitPendingWrites() {
+        executor.submit {}.get()
     }
 
     private fun load(): MutableMap<String, Any> {
@@ -73,9 +85,23 @@ internal class PostHogFilePreferences(
         }
     }
 
-    private fun persist() {
+    private fun schedulePersist() {
         try {
-            val json = config.serializer.serializeObject(preferences) ?: return
+            executor.execute {
+                val snapshot: Map<String, Any>
+                synchronized(lock) {
+                    snapshot = preferences.toMap()
+                }
+                persist(snapshot)
+            }
+        } catch (e: Throwable) {
+            config.logger.log("Failed to schedule preferences write: $e.")
+        }
+    }
+
+    private fun persist(snapshot: Map<String, Any>) {
+        try {
+            val json = config.serializer.serializeObject(snapshot) ?: return
             file.parentFile?.mkdirs()
             val tmp = File(file.parentFile, "${file.name}.tmp")
             tmp.writeText(json)

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogFilePreferences.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogFilePreferences.kt
@@ -1,0 +1,96 @@
+package com.posthog.kmp
+
+import com.posthog.internal.PostHogPreferences
+import com.posthog.internal.PostHogPreferences.Companion.ALL_INTERNAL_KEYS
+import java.io.File
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * File-backed [PostHogPreferences] so identity, opt-out state and cached feature flags
+ * survive process restarts. The store is a single JSON object; writes go to a temp file
+ * and are moved over the previous one so a crash mid-write cannot corrupt the store.
+ */
+internal class PostHogFilePreferences(
+    private val file: File,
+    private val config: com.posthog.PostHogConfig,
+) : PostHogPreferences {
+    private val lock = Any()
+    private val preferences: MutableMap<String, Any> by lazy { load() }
+
+    override fun getValue(key: String, defaultValue: Any?): Any? {
+        synchronized(lock) {
+            return preferences[key] ?: defaultValue
+        }
+    }
+
+    override fun setValue(key: String, value: Any) {
+        synchronized(lock) {
+            preferences[key] = value
+            persist()
+        }
+    }
+
+    override fun clear(except: List<String>) {
+        synchronized(lock) {
+            val it = preferences.iterator()
+            while (it.hasNext()) {
+                if (!except.contains(it.next().key)) {
+                    it.remove()
+                }
+            }
+            persist()
+        }
+    }
+
+    override fun remove(key: String) {
+        synchronized(lock) {
+            preferences.remove(key)
+            persist()
+        }
+    }
+
+    override fun getAll(): Map<String, Any> {
+        val props: Map<String, Any>
+        synchronized(lock) {
+            props = preferences.toMap()
+        }
+        return props.filterKeys { key ->
+            !ALL_INTERNAL_KEYS.contains(key)
+        }
+    }
+
+    private fun load(): MutableMap<String, Any> {
+        return try {
+            if (!file.exists()) return mutableMapOf()
+            @Suppress("UNCHECKED_CAST")
+            (config.serializer.deserializeString(file.readText()) as? Map<String, Any>)
+                ?.toMutableMap() ?: mutableMapOf()
+        } catch (e: Throwable) {
+            config.logger.log("Failed to load preferences from ${file.absolutePath}: $e.")
+            mutableMapOf()
+        }
+    }
+
+    private fun persist() {
+        try {
+            val json = config.serializer.serializeObject(preferences) ?: return
+            file.parentFile?.mkdirs()
+            val tmp = File(file.parentFile, "${file.name}.tmp")
+            tmp.writeText(json)
+            try {
+                Files.move(
+                    tmp.toPath(),
+                    file.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE
+                )
+            } catch (ignored: AtomicMoveNotSupportedException) {
+                Files.move(tmp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            }
+        } catch (e: Throwable) {
+            config.logger.log("Failed to persist preferences to ${file.absolutePath}: $e.")
+        }
+    }
+}

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogJvmContext.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogJvmContext.kt
@@ -12,11 +12,15 @@ internal class PostHogJvmContext(
 ) : com.posthog.internal.PostHogContext {
     private val cacheStaticContext by lazy {
         buildMap<String, Any> {
-            System.getProperty("os.name")?.let { put("\$os_name", it) }
+            System.getProperty("os.name")?.let { put("\$os_name", normalizeOsName(it)) }
             System.getProperty("os.version")?.let { put("\$os_version", it) }
             put("\$device_type", "Desktop")
         }
     }
+
+    // os.name on Windows includes the release ("Windows 11"); flags target plain "Windows"
+    private fun normalizeOsName(raw: String): String =
+        if (raw.startsWith("Windows")) "Windows" else raw
 
     private val cacheSdkInfo by lazy {
         mapOf<String, Any>(

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogJvmContext.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHogJvmContext.kt
@@ -1,0 +1,37 @@
+package com.posthog.kmp
+
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Event context for the JVM. [getSdkInfo] supplies `$lib`/`$lib_version` on every event —
+ * without it events are not attributed to this SDK.
+ */
+internal class PostHogJvmContext(
+    private val config: com.posthog.PostHogConfig,
+) : com.posthog.internal.PostHogContext {
+    private val cacheStaticContext by lazy {
+        buildMap<String, Any> {
+            System.getProperty("os.name")?.let { put("\$os_name", it) }
+            System.getProperty("os.version")?.let { put("\$os_version", it) }
+            put("\$device_type", "Desktop")
+        }
+    }
+
+    private val cacheSdkInfo by lazy {
+        mapOf<String, Any>(
+            "\$lib" to config.sdkName,
+            "\$lib_version" to config.sdkVersion
+        )
+    }
+
+    override fun getStaticContext(): Map<String, Any> = cacheStaticContext
+
+    override fun getDynamicContext(): Map<String, Any> =
+        mapOf(
+            "\$locale" to "${Locale.getDefault().language}-${Locale.getDefault().country}",
+            "\$timezone" to TimeZone.getDefault().id
+        )
+
+    override fun getSdkInfo(): Map<String, Any> = cacheSdkInfo
+}

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/FakePostHogInterface.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/FakePostHogInterface.kt
@@ -1,0 +1,81 @@
+package com.posthog.kmp
+
+import com.posthog.PostHogInterface
+import java.lang.reflect.Proxy
+import java.util.UUID
+
+class FakePostHogInterface {
+    val capturedEvents = mutableListOf<String>()
+    val capturedProperties = mutableListOf<Map<String, Any>?>()
+    
+    val capturedIdentify = mutableListOf<String>()
+    val capturedIdentifyProperties = mutableListOf<Map<String, Any>?>()
+    
+    val capturedScreen = mutableListOf<String>()
+    val capturedScreenProperties = mutableListOf<Map<String, Any>?>()
+
+    val calledMethods = mutableListOf<Pair<String, List<Any?>>>()
+
+    var currentSessionId: String? = "00000000-0000-0000-0000-000000000123"
+    var currentDistinctId: String = "test-distinct-id"
+    var currentAnonymousId: String = "anon-id"
+
+    val proxy: PostHogInterface = Proxy.newProxyInstance(
+        PostHogInterface::class.java.classLoader,
+        arrayOf(PostHogInterface::class.java)
+    ) { _, method, args ->
+        val methodName = method.name
+        val methodArgs = args?.toList() ?: emptyList()
+        calledMethods.add(methodName to methodArgs)
+
+        when (methodName) {
+            "capture" -> {
+                val event = args[0] as String
+                capturedEvents.add(event)
+                if (args.size > 2) {
+                    @Suppress("UNCHECKED_CAST")
+                    capturedProperties.add(args[2] as? Map<String, Any>)
+                }
+                Unit
+            }
+            "identify" -> {
+                val distinctId = args[0] as String
+                capturedIdentify.add(distinctId)
+                if (args.size > 1) {
+                    @Suppress("UNCHECKED_CAST")
+                    capturedIdentifyProperties.add(args[1] as? Map<String, Any>)
+                }
+                Unit
+            }
+            "screen" -> {
+                val title = args[0] as String
+                capturedScreen.add(title)
+                if (args.size > 1) {
+                    @Suppress("UNCHECKED_CAST")
+                    capturedScreenProperties.add(args[1] as? Map<String, Any>)
+                }
+                Unit
+            }
+            "getSessionId" -> {
+                currentSessionId?.let { UUID.fromString(it) }
+            }
+            "distinctId" -> currentDistinctId
+            "getAnonymousId" -> currentAnonymousId
+            "isFeatureEnabled" -> false
+            "getFeatureFlag" -> null
+            "getFeatureFlagResult" -> null
+            "getAllFeatureFlags" -> emptyList<Any>()
+            "isOptOut" -> false
+            else -> {
+                val returnType = method.returnType
+                when {
+                    returnType == Boolean::class.javaPrimitiveType -> false
+                    returnType == Int::class.javaPrimitiveType -> 0
+                    returnType == Long::class.javaPrimitiveType -> 0L
+                    returnType == Void.TYPE -> Unit
+                    else -> null
+                }
+            }
+        }
+    } as PostHogInterface
+}

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogFilePreferencesTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogFilePreferencesTest.kt
@@ -1,0 +1,101 @@
+package com.posthog.kmp
+
+import com.posthog.internal.PostHogPreferences.Companion.ANONYMOUS_ID
+import com.posthog.internal.PostHogPreferences.Companion.GROUPS
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PostHogFilePreferencesTest {
+
+    private val config = com.posthog.PostHogConfig(apiKey = "test-key")
+
+    private fun tempFile(): File {
+        val dir = Files.createTempDirectory("posthog-kmp-prefs").toFile()
+        dir.deleteOnExit()
+        return File(dir, "preferences.json")
+    }
+
+    @Test
+    fun returnsDefaultWhenMissing() {
+        val prefs = PostHogFilePreferences(tempFile(), config)
+        assertNull(prefs.getValue("missing"))
+        assertEquals("fallback", prefs.getValue("missing", "fallback"))
+    }
+
+    @Test
+    fun roundTripsValueTypesAcrossInstances() {
+        val file = tempFile()
+        val prefs = PostHogFilePreferences(file, config)
+        prefs.setValue(ANONYMOUS_ID, "anon-123")
+        prefs.setValue("bool", true)
+        prefs.setValue("int", 42)
+        prefs.setValue("double", 1.5)
+        prefs.setValue(GROUPS, mapOf("company" to "posthog"))
+        prefs.setValue("list", listOf("a", "b"))
+
+        val reloaded = PostHogFilePreferences(file, config)
+        assertEquals("anon-123", reloaded.getValue(ANONYMOUS_ID))
+        assertEquals(true, reloaded.getValue("bool"))
+        assertEquals(42, reloaded.getValue("int"))
+        assertEquals(1.5, reloaded.getValue("double"))
+        assertEquals(mapOf("company" to "posthog"), reloaded.getValue(GROUPS))
+        assertEquals(listOf("a", "b"), reloaded.getValue("list"))
+    }
+
+    @Test
+    fun removeDeletesKeyPersistently() {
+        val file = tempFile()
+        val prefs = PostHogFilePreferences(file, config)
+        prefs.setValue("key", "value")
+        prefs.remove("key")
+
+        assertNull(prefs.getValue("key"))
+        assertNull(PostHogFilePreferences(file, config).getValue("key"))
+    }
+
+    @Test
+    fun clearKeepsExceptedKeys() {
+        val file = tempFile()
+        val prefs = PostHogFilePreferences(file, config)
+        prefs.setValue(ANONYMOUS_ID, "anon-123")
+        prefs.setValue("other", "value")
+
+        prefs.clear(except = listOf(ANONYMOUS_ID))
+
+        assertEquals("anon-123", prefs.getValue(ANONYMOUS_ID))
+        assertNull(prefs.getValue("other"))
+
+        val reloaded = PostHogFilePreferences(file, config)
+        assertEquals("anon-123", reloaded.getValue(ANONYMOUS_ID))
+        assertNull(reloaded.getValue("other"))
+    }
+
+    @Test
+    fun getAllFiltersInternalKeys() {
+        val prefs = PostHogFilePreferences(tempFile(), config)
+        prefs.setValue(ANONYMOUS_ID, "anon-123")
+        prefs.setValue("custom", "value")
+
+        val all = prefs.getAll()
+        assertFalse(all.containsKey(ANONYMOUS_ID))
+        assertEquals("value", all["custom"])
+    }
+
+    @Test
+    fun survivesCorruptFile() {
+        val file = tempFile()
+        file.parentFile.mkdirs()
+        file.writeText("{not json")
+
+        val prefs = PostHogFilePreferences(file, config)
+        assertNull(prefs.getValue("key"))
+        prefs.setValue("key", "value")
+        assertEquals("value", PostHogFilePreferences(file, config).getValue("key"))
+        assertTrue(file.exists())
+    }
+}

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogFilePreferencesTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogFilePreferencesTest.kt
@@ -37,6 +37,7 @@ class PostHogFilePreferencesTest {
         prefs.setValue("double", 1.5)
         prefs.setValue(GROUPS, mapOf("company" to "posthog"))
         prefs.setValue("list", listOf("a", "b"))
+        prefs.awaitPendingWrites()
 
         val reloaded = PostHogFilePreferences(file, config)
         assertEquals("anon-123", reloaded.getValue(ANONYMOUS_ID))
@@ -53,6 +54,7 @@ class PostHogFilePreferencesTest {
         val prefs = PostHogFilePreferences(file, config)
         prefs.setValue("key", "value")
         prefs.remove("key")
+        prefs.awaitPendingWrites()
 
         assertNull(prefs.getValue("key"))
         assertNull(PostHogFilePreferences(file, config).getValue("key"))
@@ -66,6 +68,7 @@ class PostHogFilePreferencesTest {
         prefs.setValue("other", "value")
 
         prefs.clear(except = listOf(ANONYMOUS_ID))
+        prefs.awaitPendingWrites()
 
         assertEquals("anon-123", prefs.getValue(ANONYMOUS_ID))
         assertNull(prefs.getValue("other"))
@@ -95,6 +98,7 @@ class PostHogFilePreferencesTest {
         val prefs = PostHogFilePreferences(file, config)
         assertNull(prefs.getValue("key"))
         prefs.setValue("key", "value")
+        prefs.awaitPendingWrites()
         assertEquals("value", PostHogFilePreferences(file, config).getValue("key"))
         assertTrue(file.exists())
     }

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -1,0 +1,206 @@
+package com.posthog.kmp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.BeforeTest
+
+class PostHogJvmTest {
+
+    private lateinit var fakeInterface: FakePostHogInterface
+
+    @BeforeTest
+    fun setup() {
+        fakeInterface = FakePostHogInterface()
+        postHogInstance = fakeInterface.proxy
+        currentConfig = null
+    }
+
+    private fun assertMethodCalled(methodName: String, vararg args: Any?) {
+        val call = fakeInterface.calledMethods.find { it.first == methodName }
+        assertTrue(call != null, "Method $methodName was not called")
+        
+        args.forEachIndexed { index, expectedArg ->
+            if (expectedArg != null) {
+                assertEquals(expectedArg, call.second.getOrNull(index), "Argument at index $index mismatch for $methodName")
+            }
+        }
+    }
+
+    @Test
+    fun testCaptureRoutesCorrectly() {
+        PostHog.capture("test_event", mapOf("prop" to "value"))
+        assertMethodCalled("capture", "test_event", null, mapOf("prop" to "value"))
+    }
+
+    @Test
+    fun testCapturePassesGroupsToNativeParameter() {
+        PostHog.capture(
+            "test_event",
+            mapOf("prop" to "value"),
+            CaptureOptions(groups = mapOf("company" to "acme"))
+        )
+        // capture(event, distinctId, properties, userProperties, userPropertiesSetOnce, groups, timestamp)
+        assertMethodCalled(
+            "capture",
+            "test_event",
+            null,
+            mapOf("prop" to "value"),
+            null,
+            null,
+            mapOf("company" to "acme")
+        )
+    }
+
+    @Test
+    fun testCaptureDropsNullPropertyValues() {
+        PostHog.capture("test_event", mapOf("keep" to 1, "drop" to null))
+        assertMethodCalled("capture", "test_event", null, mapOf("keep" to 1))
+    }
+
+    @Test
+    fun testIdentifyRoutesCorrectly() {
+        PostHog.identify("user_123", mapOf("email" to "test@example.com"))
+        assertMethodCalled("identify", "user_123", mapOf("email" to "test@example.com"))
+    }
+
+    @Test
+    fun testScreenRoutesCorrectly() {
+        PostHog.screen("Home", mapOf("tab" to "feed"))
+        assertMethodCalled("screen", "Home", mapOf("tab" to "feed"))
+    }
+    
+    @Test
+    fun testSessionIdRoutesCorrectly() {
+        fakeInterface.currentSessionId = "00000000-0000-0000-0000-000000000123"
+        assertEquals("00000000-0000-0000-0000-000000000123", PostHog.getSessionId())
+    }
+
+    @Test
+    fun testDistinctIdRoutesCorrectly() {
+        fakeInterface.currentDistinctId = "distinct_123"
+        assertEquals("distinct_123", PostHog.getDistinctId())
+    }
+
+    @Test
+    fun testAliasRoutesCorrectly() {
+        PostHog.alias("new_alias")
+        assertMethodCalled("alias", "new_alias")
+    }
+
+    @Test
+    fun testResetRoutesCorrectly() {
+        PostHog.reset()
+        assertMethodCalled("reset")
+    }
+
+    @Test
+    fun testRegisterRoutesCorrectly() {
+        PostHog.register("super_prop", "value")
+        assertMethodCalled("register", "super_prop", "value")
+    }
+
+    @Test
+    fun testUnregisterRoutesCorrectly() {
+        PostHog.unregister("super_prop")
+        assertMethodCalled("unregister", "super_prop")
+    }
+
+    @Test
+    fun testGroupRoutesCorrectly() {
+        PostHog.group("company", "posthog", mapOf("plan" to "premium"))
+        assertMethodCalled("group", "company", "posthog", mapOf("plan" to "premium"))
+    }
+
+    @Test
+    fun testIsFeatureEnabledRoutesCorrectly() {
+        PostHog.isFeatureEnabled("test_flag", defaultValue = true)
+        assertMethodCalled("isFeatureEnabled", "test_flag", true, true)
+    }
+
+    @Test
+    fun testSendFeatureFlagEventFallsBackToConfig() {
+        currentConfig = PostHogConfig(apiKey = "key", sendFeatureFlagEvent = false)
+
+        PostHog.isFeatureEnabled("test_flag")
+        assertMethodCalled("isFeatureEnabled", "test_flag", false, false)
+
+        PostHog.isFeatureEnabled("test_flag", sendFeatureFlagEvent = true)
+        val overrideCall = fakeInterface.calledMethods.last { it.first == "isFeatureEnabled" }
+        assertEquals(true, overrideCall.second[2])
+    }
+
+    @Test
+    fun testGetFeatureFlagRoutesCorrectly() {
+        PostHog.getFeatureFlag("test_flag")
+        assertMethodCalled("getFeatureFlag", "test_flag")
+    }
+
+    @Test
+    fun testReloadFeatureFlagsRoutesCorrectly() {
+        PostHog.reloadFeatureFlags()
+        assertMethodCalled("reloadFeatureFlags")
+    }
+
+    @Test
+    fun testGetFeatureFlagResultRoutesCorrectly() {
+        PostHog.getFeatureFlagResult("test_flag")
+        assertMethodCalled("getFeatureFlagResult", "test_flag")
+    }
+
+    @Test
+    fun testCaptureExceptionRoutesCorrectly() {
+        val throwable = RuntimeException("Test exception")
+        PostHog.captureException(throwable, mapOf("context" to "test"))
+        assertMethodCalled("captureException", throwable, mapOf("context" to "test"))
+    }
+
+    @Test
+    fun testGetAnonymousIdRoutesCorrectly() {
+        fakeInterface.currentAnonymousId = "anon-id-123"
+        assertEquals("anon-id-123", PostHog.getAnonymousId())
+        assertMethodCalled("getAnonymousId")
+    }
+
+    @Test
+    fun testOptOutRoutesCorrectly() {
+        PostHog.optOut()
+        assertMethodCalled("optOut")
+    }
+
+    @Test
+    fun testOptInRoutesCorrectly() {
+        PostHog.optIn()
+        assertMethodCalled("optIn")
+    }
+
+    @Test
+    fun testIsOptedOutRoutesCorrectly() {
+        PostHog.isOptedOut()
+        assertMethodCalled("isOptOut")
+    }
+
+    @Test
+    fun testFlushRoutesCorrectly() {
+        PostHog.flush()
+        assertMethodCalled("flush")
+    }
+
+    @Test
+    fun testCloseRoutesCorrectly() {
+        PostHog.close()
+        assertMethodCalled("close")
+    }
+
+    @Test
+    fun testSetDebugRoutesCorrectly() {
+        PostHog.setDebug(true)
+        assertMethodCalled("debug", true)
+    }
+
+    @Test
+    fun testSetPersonPropertiesRoutesCorrectly() {
+        PostHog.setPersonProperties(mapOf("plan" to "premium"), mapOf("first_login" to true))
+        assertMethodCalled("setPersonProperties", mapOf("plan" to "premium"), mapOf("first_login" to true))
+    }
+}


### PR DESCRIPTION
Closes #6

## Problem

Compose Multiplatform apps can't compile their shared code for desktop because posthog-kmp has no JVM target — and desktop is increasingly the primary dev platform for Compose apps thanks to Compose Hot Reload (see #6). The original repo's JVM target was deleted in #1 because it was a hand-rolled HTTP pipeline with known bugs, not a wrapper over an official SDK.

## Changes

Adds a **real** JVM implementation instead of the no-op stubs requested as a floor in #6, by wrapping `com.posthog:posthog` — the pure-JVM core library posthog-android is built on. Both targets share one event pipeline, so behavior matches Android by construction.

- `jvm()` target; `jvmMain` depends on `com.posthog:posthog` (internal dependency, no new public API — the JVM actuals fill existing `expect` declarations)
- `PostHog.jvm.kt` — mirrors `PostHog.android.kt`; everything delegates to the core `PostHogInterface`. Mobile/browser-only options (session replay, lifecycle events, screen views, deep links) are ignored and documented
- `PostHogFilePreferences` — JSON-file identity cache under `~/.posthog-kmp` (atomic writes), so anonymous/distinct id, opt-out, and cached flags survive process restarts
- `PostHogJvmContext` — stamps `$lib`/`$lib_version` (SDK attribution) plus `$os_name`/`$device_type: Desktop`/locale/timezone on every event
- 32 jvmTest tests (delegation tests ported from androidHostTest + preferences tests incl. corrupt-file recovery), a JVM CI job, README docs, minor changeset

## How it was tested

- `jvmTest`, `testAndroid`, `jsTest`, `compileKotlinIosArm64`, `detekt` all green
- Live end-to-end: published to mavenLocal, built a standalone JVM consumer app against the published artifact, ran it twice, and verified in PostHog that all events ingested with correct `$lib: posthog-kmp` attribution and anonymous → `$identify` → identified linkage — including an event from a second process attributed to the identified user (identity persistence across restarts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)