### PR TITLE
ci: remove v prefix from GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,8 +239,8 @@ jobs:
           NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}
           GH_APP_TOKEN: ${{ steps.releaser.outputs.token }}
         run: |
-          git tag -a "v$NEW_VERSION" -m "v$NEW_VERSION"
-          git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "v$NEW_VERSION"
+          git tag -a "$NEW_VERSION" -m "$NEW_VERSION"
+          git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$NEW_VERSION"
 
       - name: Create GitHub Release
         if: steps.commit-version-bump.outputs.commit-hash != ''
@@ -251,9 +251,9 @@ jobs:
           # Extract the latest changelog entry (content between the first and second ## header)
           LAST_CHANGELOG_ENTRY=$(awk '/^## /{if (flag) exit; flag=1; next} flag' CHANGELOG.md | awk 'NF{f=1} f{l[++n]=$0; if(NF) last=n} END{for(i=1;i<=last;i++) print l[i]}')
           LAST_CHANGELOG_ENTRY=${LAST_CHANGELOG_ENTRY:-"see CHANGELOG.md"}
-          gh release create "v$NEW_VERSION" \
+          gh release create "$NEW_VERSION" \
             --target main \
-            --title "v$NEW_VERSION" \
+            --title "$NEW_VERSION" \
             --notes "$LAST_CHANGELOG_ENTRY"
 
       - name: Notify Slack - Failed


### PR DESCRIPTION
## :bulb: Motivation and Context

GitHub tags and releases should use the package version directly without a `v` prefix.

This updates the release workflow to:
- Create and push tags such as `0.1.0` instead of `v0.1.0`.
- Create GitHub Releases with unprefixed tag names and titles.

## :green_heart: How did you test it?

- Ran `git diff --check`.
- Parsed `.github/workflows/release.yml` successfully with Ruby's YAML parser.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent at the user's direction. The change is limited to release tag and GitHub Release naming; no package changeset was added because this only adjusts CI release metadata.
