### PR TITLE
ci: arm auto-merge on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,7 +15,12 @@ jobs:
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        # The guard keeps re-runs (e.g. after a dependabot rebase triggers a
+        # synchronize event) from failing on an already-armed PR.
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "false" ]; then
+              gh pr merge --auto --squash "$PR_URL"
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+
+# Arms GitHub auto-merge on dependabot PRs so they merge on their own once a
+# code owner approves and all required checks pass. It does not approve
+# anything itself - the "Review request" ruleset still requires a human review.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Dependabot batches arrive weekly and each PR needs someone to babysit it: approve, wait for CI, come back, merge (see #16–#27, where auto-merge had to be armed by hand).

## Changes

Adds a workflow that enables GitHub auto-merge (squash) on every dependabot PR as soon as it opens. Nothing is bypassed and nothing is auto-approved — the `Review request` ruleset still requires a code owner review and all 6 required checks. The only change is that once you approve, the PR merges itself when CI is green.

Uses only the built-in `gh` CLI with `GITHUB_TOKEN` — no third-party actions to pin. Guarded to same-repo PRs actually authored by `dependabot[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)