### PR TITLE
fix: configure Compose Desktop release packaging

### DIFF
--- a/.changeset/calm-pumas-report.md
+++ b/.changeset/calm-pumas-report.md
@@ -2,4 +2,4 @@
 'posthog-kmp': patch
 ---
 
-Document the required Compose Desktop release configuration and add a working macOS sample package.
+Fix Compose Desktop release networking with a compatible Okio version and document the required packaging configuration.

--- a/.changeset/calm-pumas-report.md
+++ b/.changeset/calm-pumas-report.md
@@ -1,0 +1,5 @@
+---
+'posthog-kmp': patch
+---
+
+Document the required Compose Desktop release configuration and add a working macOS sample package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Build iOS
         run: ./gradlew :posthog-kmp:compileKotlinIosArm64 --no-daemon
 
+      - name: Build macOS desktop sample release
+        run: ./gradlew :sample:packageReleaseDmg --no-daemon
+
   release-dry-run:
     name: Release Dry Run
     runs-on: ubuntu-latest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidx-activity-compose = "1.13.0"
 posthog-android = "3.55.2"
 # Pure-JVM core that posthog-android is built on (versioned independently of posthog-android)
 posthog-core = "6.26.1"
+okio = "3.18.1"
 posthog-ios = "3.64.1"
 posthog-js = "1.398.7"
 mavenPublish = "0.37.0"
@@ -26,7 +27,7 @@ kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", versio
 # PostHog SDKs
 posthog-android = { group = "com.posthog", name = "posthog-android", version.ref = "posthog-android" }
 posthog-core = { group = "com.posthog", name = "posthog", version.ref = "posthog-core" }
-
+okio-jvm = { group = "com.squareup.okio", name = "okio-jvm", version.ref = "okio" }
 
 # Testing
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin-test" }

--- a/posthog-kmp/build.gradle.kts
+++ b/posthog-kmp/build.gradle.kts
@@ -155,8 +155,12 @@ kotlin {
             }
         }
 
-        val jvmMain by getting {
+        getByName("jvmMain") {
             dependsOn(jvmCommonMain)
+            dependencies {
+                // Okio 3.6.0 can produce invalid bytecode when optimized by Compose Desktop's ProGuard.
+                implementation(libs.okio.jvm)
+            }
         }
     }
 }

--- a/sample/README.md
+++ b/sample/README.md
@@ -19,6 +19,6 @@ Build the macOS release DMG:
 Compose Desktop release distributions use ProGuard and a custom JDK runtime. Apps using PostHog must:
 
 1. Add `jdk.unsupported` to `nativeDistributions.modules`. Gson uses this module to deserialize PostHog queue and API models.
-2. Include the PostHog release rules from [`compose-desktop.pro`](compose-desktop.pro). They preserve reflection-based models and prevent ProGuard from producing invalid Okio bytecode.
+2. Include the PostHog release rules from [`compose-desktop.pro`](compose-desktop.pro). They preserve reflection-based PostHog and Gson models.
 
 See [`build.gradle.kts`](build.gradle.kts) for the complete configuration.

--- a/sample/README.md
+++ b/sample/README.md
@@ -1,0 +1,24 @@
+# PostHog KMP sample
+
+The sample runs on Android, iOS, Web, and JVM desktop.
+
+## JVM desktop
+
+Run the app from Gradle:
+
+```bash
+./gradlew :sample:run
+```
+
+Build the macOS release DMG:
+
+```bash
+./gradlew :sample:packageReleaseDmg
+```
+
+Compose Desktop release distributions use ProGuard and a custom JDK runtime. Apps using PostHog must:
+
+1. Add `jdk.unsupported` to `nativeDistributions.modules`. Gson uses this module to deserialize PostHog queue and API models.
+2. Include the PostHog release rules from [`compose-desktop.pro`](compose-desktop.pro). They preserve reflection-based models and prevent ProGuard from producing invalid Okio bytecode.
+
+See [`build.gradle.kts`](build.gradle.kts) for the complete configuration.

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidKmpLibrary)
@@ -37,6 +39,8 @@ kotlin {
         binaries.executable()
     }
 
+    jvm()
+
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -62,6 +66,29 @@ kotlin {
 
         getByName("wasmJsMain") {
             dependsOn(commonMain)
+        }
+
+        getByName("jvmMain") {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+            }
+        }
+    }
+}
+
+compose.desktop {
+    application {
+        mainClass = "com.posthog.kmp.sample.MainKt"
+
+        buildTypes.release.proguard {
+            configurationFiles.from(project.file("compose-desktop.pro"))
+        }
+
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg)
+            modules("jdk.unsupported")
+            packageName = "PostHog KMP Sample"
+            packageVersion = "1.0.0"
         }
     }
 }

--- a/sample/compose-desktop.pro
+++ b/sample/compose-desktop.pro
@@ -3,9 +3,6 @@
 -keep class com.posthog.** { *; }
 -keep class com.google.gson.** { *; }
 
-# Compose Desktop's ProGuard optimizer can produce invalid Okio bridge return types.
--keep class okio.** { *; }
-
 # OkHttp probes optional platform and TLS provider classes at runtime.
 -dontwarn android.**
 -dontwarn dalvik.**

--- a/sample/compose-desktop.pro
+++ b/sample/compose-desktop.pro
@@ -1,0 +1,19 @@
+# PostHog uses Gson reflection for its queue and API payloads.
+-keepattributes Signature,*Annotation*
+-keep class com.posthog.** { *; }
+-keep class com.google.gson.** { *; }
+
+# Compose Desktop's ProGuard optimizer can produce invalid Okio bridge return types.
+-keep class okio.** { *; }
+
+# OkHttp probes optional platform and TLS provider classes at runtime.
+-dontwarn android.**
+-dontwarn dalvik.**
+-dontwarn javax.annotation.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.conscrypt.**
+-dontwarn org.openjsse.**
+-dontwarn org.codehaus.mojo.animal_sniffer.**
+-dontwarn com.jetbrains.SharedTextures
+
+-adaptresourcefilenames okhttp3/internal/publicsuffix/PublicSuffixDatabase.gz

--- a/sample/src/jvmMain/kotlin/com/posthog/kmp/sample/Main.kt
+++ b/sample/src/jvmMain/kotlin/com/posthog/kmp/sample/Main.kt
@@ -1,0 +1,14 @@
+package com.posthog.kmp.sample
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.posthog.kmp.PostHogContext
+
+fun main() = application {
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "PostHog KMP Sample",
+    ) {
+        App(PostHogContext())
+    }
+}

--- a/sample/src/jvmMain/kotlin/com/posthog/kmp/sample/Platform.jvm.kt
+++ b/sample/src/jvmMain/kotlin/com/posthog/kmp/sample/Platform.jvm.kt
@@ -1,0 +1,3 @@
+package com.posthog.kmp.sample
+
+actual fun getPlatformName(): String = System.getProperty("os.name") ?: "JVM"


### PR DESCRIPTION
## :bulb: Motivation and Context

Compose Desktop release packages could queue PostHog events without sending them because the custom runtime omitted `jdk.unsupported`, ProGuard stripped reflection-dependent PostHog/Gson models, and the transitive Okio 3.6.0 produced invalid optimized bytecode. This fixes #42 by using Okio 3.18.1 for the JVM target and adding a validated desktop release configuration and sample.

## :green_heart: How did you test it?

- `./gradlew detekt :posthog-kmp:jvmTest :sample:packageReleaseDmg --no-daemon --no-build-cache --rerun-tasks` with JDK 17
- `./gradlew :sample:dependencyInsight --dependency com.squareup.okio:okio-jvm --configuration jvmRuntimeClasspath --no-daemon` resolves Okio 3.18.1 over 3.6.0
- Ran the optimized release jars with JVM bytecode verification enabled and verified that `https://us.i.posthog.com/batch` returned `{"status":"Ok"}` and the SDK logged `Flushed 1 events successfully.`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent, with advisory review from Pi's advisor/reviewer agents and the isolated autoreview tool. Okio is pinned only for the JVM publication; Android dependency resolution is unchanged. The application-level `jdk.unsupported` module and reflection rules remain necessary for Compose Desktop packaging. A human review is still required.
