### PR TITLE
chore: add changeset for dependency updates

### DIFF
--- a/.changeset/swift-dingos-update.md
+++ b/.changeset/swift-dingos-update.md
@@ -1,0 +1,5 @@
+---
+'posthog-kmp': patch
+---
+
+Update the Android SDK to 3.56.4 and the JVM core SDK to 6.27.0, bringing error tracking, session replay, and performance fixes.


### PR DESCRIPTION
## :bulb: Motivation and Context

The recently merged `com.posthog:posthog-android` 3.56.4 and `com.posthog:posthog` 6.27.0 dependency updates did not include a change intent, so their user-visible fixes would be missing from the next `posthog-kmp` release notes.

This adds a patch change intent covering both dependency updates for the `posthog-kmp` package.

## :green_heart: How did you test it?

- `corepack pnpm@11.20.0 change status`
- `git diff --check`
- Isolated autoreview against `origin/main`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and reviewed with Pi's isolated autoreview tool. The change intent was created directly in the repository's established format and validated with pnpm 11.20.0 because the locally installed pnpm 11.9.0 predates the `pnpm change` command. A human review is still required.
