### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      release-tooling:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7
     commit-message:
@@ -16,6 +20,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7
     commit-message:
@@ -27,6 +35,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"
     cooldown:
       default-days: 7
     commit-message:


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot currently opens separate weekly pull requests for updates in each configured ecosystem. Grouping updates reduces pull request volume while keeping npm, GitHub Actions, and Gradle updates separate, as required by Dependabot.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` and verified all three entries keep their root directory, weekly schedule, seven-day cooldown, commit prefix, and pull request limit.
- Verified each ecosystem has exactly one catch-all group with `patterns: ["*"]`.
- Verified the root entries cover the repository's npm, GitHub Actions, and Gradle manifests.
- Verified the wildcard CODEOWNERS rule covers `.github/dependabot.yml`.
- Ran autoreview against `origin/main` with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi agent used the PR, autoreview, and check-pr skills in the current local session. No shareable session link is available. The requested ecosystem-specific catch-all groups were added without changing any existing Dependabot settings. Autoreview reported no actionable findings.
