### PR TITLE
feat: add before-send event filtering

### DIFF
--- a/.changeset/calm-events-filter.md
+++ b/.changeset/calm-events-filter.md
@@ -1,0 +1,5 @@
+---
+'posthog-kmp': minor
+---
+
+Add before-send callbacks for modifying or dropping events on Android, iOS, JVM, JS, and Wasm.

--- a/posthog-kmp/src/androidMain/kotlin/com/posthog/kmp/PostHog.android.kt
+++ b/posthog-kmp/src/androidMain/kotlin/com/posthog/kmp/PostHog.android.kt
@@ -27,6 +27,7 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         optOut = config.optOut
 
         personProfiles = config.personProfiles.toCorePersonProfiles()
+        configureBeforeSend(config)
 
         config.sessionRecording?.let { sessionConfig ->
             sessionReplay = sessionConfig.enabled

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogBeforeSend.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogBeforeSend.kt
@@ -9,23 +9,32 @@ package com.posthog.kmp
 public data class PostHogEvent(
     val event: String,
     val distinctId: String,
-    val properties: Map<String, Any>
+    val properties: Map<String, Any?>
 )
 
 /**
  * Synchronous hook invoked before an event is queued.
  *
  * Callbacks run in configuration order. Return the same or a modified [PostHogEvent] to continue,
- * or `null` to drop the event and skip the remaining callbacks.
+ * or `null` to drop the event and skip the remaining callbacks. If a callback throws, its changes
+ * are ignored and the remaining callbacks continue with the last valid event.
  */
 public fun interface PostHogBeforeSend {
     public fun run(event: PostHogEvent): PostHogEvent?
 }
 
-internal fun PostHogConfig.runBeforeSend(event: PostHogEvent): PostHogEvent? {
-    var current: PostHogEvent? = event
+internal fun PostHogConfig.runBeforeSend(
+    event: PostHogEvent,
+    onError: (Throwable) -> Unit = {}
+): PostHogEvent? {
+    var current = event
     for (callback in beforeSend) {
-        current = current?.let(callback::run) ?: return null
+        current = try {
+            callback.run(current) ?: return null
+        } catch (error: Throwable) {
+            onError(error)
+            current
+        }
     }
     return current
 }

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogBeforeSend.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogBeforeSend.kt
@@ -1,0 +1,31 @@
+package com.posthog.kmp
+
+/**
+ * Event passed to [PostHogBeforeSend] callbacks before it is queued.
+ *
+ * Return a copied event to change its name, distinct ID, or properties without mutating the
+ * original event. Platform metadata not exposed here, such as the timestamp and UUID, is preserved.
+ */
+public data class PostHogEvent(
+    val event: String,
+    val distinctId: String,
+    val properties: Map<String, Any>
+)
+
+/**
+ * Synchronous hook invoked before an event is queued.
+ *
+ * Callbacks run in configuration order. Return the same or a modified [PostHogEvent] to continue,
+ * or `null` to drop the event and skip the remaining callbacks.
+ */
+public fun interface PostHogBeforeSend {
+    public fun run(event: PostHogEvent): PostHogEvent?
+}
+
+internal fun PostHogConfig.runBeforeSend(event: PostHogEvent): PostHogEvent? {
+    var current: PostHogEvent? = event
+    for (callback in beforeSend) {
+        current = current?.let(callback::run) ?: return null
+    }
+    return current
+}

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -37,9 +37,11 @@ public data class PostHogConfig(
     val optOut: Boolean = false,
     val personProfiles: PersonProfiles = PersonProfiles.IDENTIFIED_ONLY,
     val sessionRecording: SessionRecordingConfig? = null,
-    val autocapture: Boolean = false,
-    val beforeSend: List<PostHogBeforeSend> = emptyList()
+    val autocapture: Boolean = false
 ) {
+    /** Synchronous callbacks that can modify or drop events before they are queued. */
+    public var beforeSend: List<PostHogBeforeSend> = emptyList()
+
     public companion object {
         /** PostHog US Cloud instance */
         public const val HOST_US: String = "https://us.i.posthog.com"

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -19,6 +19,7 @@ package com.posthog.kmp
  * @property personProfiles Person profile mode for feature flag targeting
  * @property sessionRecording Enable session recording (platform dependent)
  * @property autocapture Enable automatic event capture (platform dependent)
+ * @property beforeSend Synchronous callbacks that can modify or drop events before they are queued
  */
 public data class PostHogConfig(
     val apiKey: String,
@@ -36,7 +37,8 @@ public data class PostHogConfig(
     val optOut: Boolean = false,
     val personProfiles: PersonProfiles = PersonProfiles.IDENTIFIED_ONLY,
     val sessionRecording: SessionRecordingConfig? = null,
-    val autocapture: Boolean = false
+    val autocapture: Boolean = false,
+    val beforeSend: List<PostHogBeforeSend> = emptyList()
 ) {
     public companion object {
         /** PostHog US Cloud instance */

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -37,10 +37,84 @@ public data class PostHogConfig(
     val optOut: Boolean = false,
     val personProfiles: PersonProfiles = PersonProfiles.IDENTIFIED_ONLY,
     val sessionRecording: SessionRecordingConfig? = null,
-    val autocapture: Boolean = false
+    val autocapture: Boolean = false,
+    val beforeSend: List<PostHogBeforeSend> = emptyList()
 ) {
-    /** Synchronous callbacks that can modify or drop events before they are queued. */
-    public var beforeSend: List<PostHogBeforeSend> = emptyList()
+    @Deprecated("Retained for binary compatibility", level = DeprecationLevel.HIDDEN)
+    public constructor(
+        apiKey: String,
+        host: String = "https://us.i.posthog.com",
+        debug: Boolean = false,
+        captureApplicationLifecycleEvents: Boolean = true,
+        captureScreenViews: Boolean = false,
+        captureDeepLinks: Boolean = true,
+        sendFeatureFlagEvent: Boolean = true,
+        preloadFeatureFlags: Boolean = true,
+        flushAt: Int = 20,
+        flushIntervalSeconds: Int = 30,
+        maxQueueSize: Int = 1000,
+        maxBatchSize: Int = 50,
+        optOut: Boolean = false,
+        personProfiles: PersonProfiles = PersonProfiles.IDENTIFIED_ONLY,
+        sessionRecording: SessionRecordingConfig? = null,
+        autocapture: Boolean = false
+    ) : this(
+        apiKey = apiKey,
+        host = host,
+        debug = debug,
+        captureApplicationLifecycleEvents = captureApplicationLifecycleEvents,
+        captureScreenViews = captureScreenViews,
+        captureDeepLinks = captureDeepLinks,
+        sendFeatureFlagEvent = sendFeatureFlagEvent,
+        preloadFeatureFlags = preloadFeatureFlags,
+        flushAt = flushAt,
+        flushIntervalSeconds = flushIntervalSeconds,
+        maxQueueSize = maxQueueSize,
+        maxBatchSize = maxBatchSize,
+        optOut = optOut,
+        personProfiles = personProfiles,
+        sessionRecording = sessionRecording,
+        autocapture = autocapture,
+        beforeSend = emptyList()
+    )
+
+    @Deprecated("Retained for binary compatibility", level = DeprecationLevel.HIDDEN)
+    public fun copy(
+        apiKey: String = this.apiKey,
+        host: String = this.host,
+        debug: Boolean = this.debug,
+        captureApplicationLifecycleEvents: Boolean = this.captureApplicationLifecycleEvents,
+        captureScreenViews: Boolean = this.captureScreenViews,
+        captureDeepLinks: Boolean = this.captureDeepLinks,
+        sendFeatureFlagEvent: Boolean = this.sendFeatureFlagEvent,
+        preloadFeatureFlags: Boolean = this.preloadFeatureFlags,
+        flushAt: Int = this.flushAt,
+        flushIntervalSeconds: Int = this.flushIntervalSeconds,
+        maxQueueSize: Int = this.maxQueueSize,
+        maxBatchSize: Int = this.maxBatchSize,
+        optOut: Boolean = this.optOut,
+        personProfiles: PersonProfiles = this.personProfiles,
+        sessionRecording: SessionRecordingConfig? = this.sessionRecording,
+        autocapture: Boolean = this.autocapture
+    ): PostHogConfig = PostHogConfig(
+        apiKey = apiKey,
+        host = host,
+        debug = debug,
+        captureApplicationLifecycleEvents = captureApplicationLifecycleEvents,
+        captureScreenViews = captureScreenViews,
+        captureDeepLinks = captureDeepLinks,
+        sendFeatureFlagEvent = sendFeatureFlagEvent,
+        preloadFeatureFlags = preloadFeatureFlags,
+        flushAt = flushAt,
+        flushIntervalSeconds = flushIntervalSeconds,
+        maxQueueSize = maxQueueSize,
+        maxBatchSize = maxBatchSize,
+        optOut = optOut,
+        personProfiles = personProfiles,
+        sessionRecording = sessionRecording,
+        autocapture = autocapture,
+        beforeSend = beforeSend
+    )
 
     public companion object {
         /** PostHog US Cloud instance */

--- a/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
+++ b/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
@@ -28,15 +28,14 @@ class PostHogConfigTest {
 
     @Test
     fun beforeSendCallbacksRunInOrder() {
-        val config = PostHogConfig(
-            apiKey = "phc_test",
+        val config = PostHogConfig(apiKey = "phc_test").apply {
             beforeSend = listOf(
                 PostHogBeforeSend { it.copy(properties = it.properties + ("first" to true)) },
                 PostHogBeforeSend {
                     it.copy(properties = it.properties + ("saw_first" to it.properties.containsKey("first")))
                 }
             )
-        )
+        }
 
         val result = config.runBeforeSend(PostHogEvent("checkout", "user-1", emptyMap()))
 
@@ -46,8 +45,7 @@ class PostHogConfigTest {
     @Test
     fun beforeSendStopsAfterDroppedEvent() {
         var finalCallbackCalled = false
-        val config = PostHogConfig(
-            apiKey = "phc_test",
+        val config = PostHogConfig(apiKey = "phc_test").apply {
             beforeSend = listOf(
                 PostHogBeforeSend { null },
                 PostHogBeforeSend {
@@ -55,7 +53,7 @@ class PostHogConfigTest {
                     it
                 }
             )
-        )
+        }
 
         assertNull(config.runBeforeSend(PostHogEvent("checkout", "user-1", emptyMap())))
         assertEquals(false, finalCallbackCalled)

--- a/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
+++ b/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
@@ -28,14 +28,15 @@ class PostHogConfigTest {
 
     @Test
     fun beforeSendCallbacksRunInOrder() {
-        val config = PostHogConfig(apiKey = "phc_test").apply {
+        val config = PostHogConfig(
+            apiKey = "phc_test",
             beforeSend = listOf(
                 PostHogBeforeSend { it.copy(properties = it.properties + ("first" to true)) },
                 PostHogBeforeSend {
                     it.copy(properties = it.properties + ("saw_first" to it.properties.containsKey("first")))
                 }
             )
-        }
+        )
 
         val result = config.runBeforeSend(PostHogEvent("checkout", "user-1", emptyMap()))
 
@@ -43,9 +44,20 @@ class PostHogConfigTest {
     }
 
     @Test
+    fun copyPreservesBeforeSendCallbacks() {
+        val callback = PostHogBeforeSend { it }
+        val config = PostHogConfig(apiKey = "phc_test", beforeSend = listOf(callback))
+
+        val copy = config.copy(debug = true)
+
+        assertEquals(listOf(callback), copy.beforeSend)
+    }
+
+    @Test
     fun beforeSendStopsAfterDroppedEvent() {
         var finalCallbackCalled = false
-        val config = PostHogConfig(apiKey = "phc_test").apply {
+        val config = PostHogConfig(
+            apiKey = "phc_test",
             beforeSend = listOf(
                 PostHogBeforeSend { null },
                 PostHogBeforeSend {
@@ -53,7 +65,7 @@ class PostHogConfigTest {
                     it
                 }
             )
-        }
+        )
 
         assertNull(config.runBeforeSend(PostHogEvent("checkout", "user-1", emptyMap())))
         assertEquals(false, finalCallbackCalled)

--- a/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
+++ b/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
@@ -2,6 +2,7 @@ package com.posthog.kmp
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class PostHogConfigTest {
 
@@ -23,5 +24,40 @@ class PostHogConfigTest {
         assertEquals(false, config.captureLogs)
         assertEquals(true, config.captureLogcat)
         assertEquals(1000L, config.debouncerDelayMs)
+    }
+
+    @Test
+    fun beforeSendCallbacksRunInOrder() {
+        val config = PostHogConfig(
+            apiKey = "phc_test",
+            beforeSend = listOf(
+                PostHogBeforeSend { it.copy(properties = it.properties + ("first" to true)) },
+                PostHogBeforeSend {
+                    it.copy(properties = it.properties + ("saw_first" to it.properties.containsKey("first")))
+                }
+            )
+        )
+
+        val result = config.runBeforeSend(PostHogEvent("checkout", "user-1", emptyMap()))
+
+        assertEquals(mapOf("first" to true, "saw_first" to true), result?.properties)
+    }
+
+    @Test
+    fun beforeSendStopsAfterDroppedEvent() {
+        var finalCallbackCalled = false
+        val config = PostHogConfig(
+            apiKey = "phc_test",
+            beforeSend = listOf(
+                PostHogBeforeSend { null },
+                PostHogBeforeSend {
+                    finalCallbackCalled = true
+                    it
+                }
+            )
+        )
+
+        assertNull(config.runBeforeSend(PostHogEvent("checkout", "user-1", emptyMap())))
+        assertEquals(false, finalCallbackCalled)
     }
 }

--- a/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
+++ b/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
@@ -54,6 +54,25 @@ class PostHogConfigTest {
     }
 
     @Test
+    fun beforeSendContinuesAfterCallbackException() {
+        var errorCount = 0
+        val config = PostHogConfig(
+            apiKey = "phc_test",
+            beforeSend = listOf(
+                PostHogBeforeSend { throw IllegalStateException("failed") },
+                PostHogBeforeSend { it.copy(event = "continued") }
+            )
+        )
+
+        val result = config.runBeforeSend(PostHogEvent("checkout", "user-1", emptyMap())) {
+            errorCount++
+        }
+
+        assertEquals("continued", result?.event)
+        assertEquals(1, errorCount)
+    }
+
+    @Test
     fun beforeSendStopsAfterDroppedEvent() {
         var finalCallbackCalled = false
         val config = PostHogConfig(

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -5,6 +5,7 @@ package com.posthog.kmp
 import PostHogBridge.PostHogBridge
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDate
+import platform.Foundation.NSLog
 import platform.Foundation.dateWithTimeIntervalSince1970
 
 /**
@@ -54,11 +55,13 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
 private fun processBeforeSend(config: PostHogConfig, event: Map<Any?, *>?): Map<Any?, *>? {
     event ?: return null
     val postHogEvent = event.toPostHogEvent() ?: return null
-    val processed = config.runBeforeSend(postHogEvent) ?: return null
+    val processed = config.runBeforeSend(postHogEvent) {
+        if (config.debug) NSLog("[PostHog] Before-send callback failed and was ignored.")
+    } ?: return null
     return mapOf(
         "event" to processed.event,
         "distinctId" to processed.distinctId,
-        "properties" to processed.properties
+        "properties" to processed.properties.filterValues { it != null }
     )
 }
 

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -53,20 +53,25 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
 
 private fun processBeforeSend(config: PostHogConfig, event: Map<Any?, *>?): Map<Any?, *>? {
     event ?: return null
-    val eventName = event["event"] as? String ?: return event
-    val distinctId = event["distinctId"] as? String ?: return event
-    val nativeProperties = event["properties"] as? Map<*, *> ?: emptyMap<Any?, Any?>()
-    val properties = buildMap {
-        for ((key, value) in nativeProperties) {
-            if (key is String && value != null) put(key, value)
-        }
-    }
-    val processed = config.runBeforeSend(PostHogEvent(eventName, distinctId, properties)) ?: return null
+    val postHogEvent = event.toPostHogEvent() ?: return null
+    val processed = config.runBeforeSend(postHogEvent) ?: return null
     return mapOf(
         "event" to processed.event,
         "distinctId" to processed.distinctId,
         "properties" to processed.properties
     )
+}
+
+private fun Map<Any?, *>.toPostHogEvent(): PostHogEvent? {
+    val eventName = this["event"] as? String ?: return null
+    val distinctId = this["distinctId"] as? String ?: return null
+    val nativeProperties = this["properties"] as? Map<*, *> ?: return null
+    val properties = buildMap {
+        for ((key, value) in nativeProperties) {
+            if (key is String && value != null) put(key, value)
+        }
+    }
+    return PostHogEvent(eventName, distinctId, properties)
 }
 
 internal actual fun platformCapture(

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -42,7 +42,30 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         sessionRecordingCaptureLogs = sessionConfig?.captureLogs ?: false,
         sessionRecordingScreenshotMode = sessionConfig?.screenshot ?: false,
         autocapture = config.autocapture,
-        sdkVersion = PostHogKmpVersion.VERSION
+        sdkVersion = PostHogKmpVersion.VERSION,
+        beforeSend = if (config.beforeSend.isEmpty()) {
+            null
+        } else {
+            { event -> processBeforeSend(config, event) }
+        }
+    )
+}
+
+private fun processBeforeSend(config: PostHogConfig, event: Map<Any?, *>?): Map<Any?, *>? {
+    event ?: return null
+    val eventName = event["event"] as? String ?: return event
+    val distinctId = event["distinctId"] as? String ?: return event
+    val nativeProperties = event["properties"] as? Map<*, *> ?: emptyMap<Any?, Any?>()
+    val properties = buildMap {
+        for ((key, value) in nativeProperties) {
+            if (key is String && value != null) put(key, value)
+        }
+    }
+    val processed = config.runBeforeSend(PostHogEvent(eventName, distinctId, properties)) ?: return null
+    return mapOf(
+        "event" to processed.event,
+        "distinctId" to processed.distinctId,
+        "properties" to processed.properties
     )
 }
 

--- a/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
+++ b/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
@@ -318,15 +318,20 @@ private fun logError(operation: String, error: Throwable) {
 private fun processBeforeSend(config: PostHogConfig, captureResult: dynamic): dynamic {
     if (captureResult == null || captureResult == undefined) return null
 
-    val event = captureResult.event as? String ?: return captureResult
-    val properties = dynamicToMap(captureResult.properties)
-    val distinctId = properties["distinct_id"] as? String ?: return captureResult
-    val processed = config.runBeforeSend(PostHogEvent(event, distinctId, properties - "distinct_id")) ?: return null
+    val event = dynamicToPostHogEvent(captureResult) ?: return null
+    val processed = config.runBeforeSend(event) ?: return null
 
     captureResult.event = processed.event
     captureResult.properties = processed.properties.toJsObject()
     captureResult.properties["distinct_id"] = processed.distinctId
     return captureResult
+}
+
+private fun dynamicToPostHogEvent(captureResult: dynamic): PostHogEvent? {
+    val event = captureResult.event as? String ?: return null
+    val properties = dynamicToMap(captureResult.properties)
+    val distinctId = properties["distinct_id"] as? String ?: return null
+    return PostHogEvent(event, distinctId, properties - "distinct_id")
 }
 
 private fun dynamicToMap(value: dynamic): Map<String, Any> {

--- a/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
+++ b/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
@@ -40,6 +40,12 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
     options["persistence"] = "localStorage"
     options["defaults"] = "2026-05-30"
     options["bootstrap"] = js("{}")
+
+    if (config.beforeSend.isNotEmpty()) {
+        options["before_send"] = { captureResult: dynamic ->
+            processBeforeSend(config, captureResult)
+        }
+    }
     
     options["person_profiles"] = when (config.personProfiles) {
         PersonProfiles.ALWAYS -> "always"
@@ -307,6 +313,48 @@ internal actual fun platformSetDebug(enabled: Boolean) {
 
 private fun logError(operation: String, error: Throwable) {
     console.error("[PostHog] $operation failed", error)
+}
+
+private fun processBeforeSend(config: PostHogConfig, captureResult: dynamic): dynamic {
+    if (captureResult == null || captureResult == undefined) return null
+
+    val event = captureResult.event as? String ?: return captureResult
+    val properties = dynamicToMap(captureResult.properties)
+    val distinctId = properties["distinct_id"] as? String ?: return captureResult
+    val processed = config.runBeforeSend(PostHogEvent(event, distinctId, properties - "distinct_id")) ?: return null
+
+    captureResult.event = processed.event
+    captureResult.properties = processed.properties.toJsObject()
+    captureResult.properties["distinct_id"] = processed.distinctId
+    return captureResult
+}
+
+private fun dynamicToMap(value: dynamic): Map<String, Any> {
+    if (value == null || value == undefined) return emptyMap()
+    val keys: Array<String> = js("Object.keys(value)")
+    return buildMap {
+        for (key in keys) {
+            dynamicToKotlinValue(value[key])?.let { put(key, it) }
+        }
+    }
+}
+
+private fun dynamicToKotlinValue(value: dynamic): Any? {
+    if (value == null || value == undefined) return null
+    return when (jsTypeOf(value)) {
+        "string", "boolean", "number" -> value
+        "object" -> when {
+            js("Array.isArray(value)") as Boolean -> {
+                val length = value.length as Int
+                List(length) { index -> dynamicToKotlinValue(value[index]) }
+            }
+            js("Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null") as Boolean -> {
+                dynamicToMap(value)
+            }
+            else -> value
+        }
+        else -> value
+    }
 }
 
 private fun Map<String, Any?>.toJsObject(): dynamic {

--- a/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
+++ b/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
@@ -318,13 +318,20 @@ private fun logError(operation: String, error: Throwable) {
 private fun processBeforeSend(config: PostHogConfig, captureResult: dynamic): dynamic {
     if (captureResult == null || captureResult == undefined) return null
 
-    val event = dynamicToPostHogEvent(captureResult) ?: return null
-    val processed = config.runBeforeSend(event) ?: return null
+    return try {
+        val event = dynamicToPostHogEvent(captureResult) ?: return null
+        val processed = config.runBeforeSend(event) {
+            if (config.debug) console.error("[PostHog] Before-send callback failed and was ignored.")
+        } ?: return null
 
-    captureResult.event = processed.event
-    captureResult.properties = processed.properties.toJsObject()
-    captureResult.properties["distinct_id"] = processed.distinctId
-    return captureResult
+        captureResult.event = processed.event
+        captureResult.properties = processed.properties.toJsObject()
+        captureResult.properties["distinct_id"] = processed.distinctId
+        captureResult
+    } catch (_: Throwable) {
+        if (config.debug) console.error("[PostHog] Before-send processing failed; event was dropped.")
+        null
+    }
 }
 
 private fun dynamicToPostHogEvent(captureResult: dynamic): PostHogEvent? {
@@ -334,15 +341,19 @@ private fun dynamicToPostHogEvent(captureResult: dynamic): PostHogEvent? {
     return PostHogEvent(event, distinctId, properties - "distinct_id")
 }
 
-private fun dynamicToMap(value: dynamic): Map<String, Any> {
+private fun dynamicToMap(value: dynamic): Map<String, Any?> {
     if (value == null || value == undefined) return emptyMap()
     val keys: Array<String> = js("Object.keys(value)")
     return buildMap {
         for (key in keys) {
-            dynamicToKotlinValue(value[key])?.let { put(key, it) }
+            val propertyValue = value[key]
+            if (!isUndefined(propertyValue)) put(key, dynamicToKotlinValue(propertyValue))
         }
     }
 }
+
+@Suppress("UNUSED_PARAMETER")
+private fun isUndefined(value: dynamic): Boolean = js("value === undefined")
 
 private fun dynamicToKotlinValue(value: dynamic): Any? {
     if (value == null || value == undefined) return null
@@ -364,19 +375,17 @@ private fun dynamicToKotlinValue(value: dynamic): Any? {
 
 private fun Map<String, Any?>.toJsObject(): dynamic {
     val obj = js("{}")
-    this.forEach { (key, value) ->
-        obj[key] = when (value) {
-            is Map<*, *> -> (value as Map<String, Any?>).toJsObject()
-            is List<*> -> value.map { item ->
-                when (item) {
-                    is Map<*, *> -> (item as Map<String, Any?>).toJsObject()
-                    else -> item
-                }
-            }.toTypedArray()
-            else -> value
-        }
-    }
+    forEach { (key, value) -> obj[key] = value.toJsValue() }
     return obj
+}
+
+private fun Any?.toJsValue(): dynamic = when (this) {
+    is Map<*, *> -> {
+        @Suppress("UNCHECKED_CAST")
+        (this as Map<String, Any?>).toJsObject()
+    }
+    is List<*> -> map { it.toJsValue() }.toTypedArray()
+    else -> this
 }
 
 internal actual fun platformSetPersonProperties(

--- a/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
+++ b/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnusedParameter")
+
 package com.posthog.kmp
 
 import kotlin.test.Test
@@ -312,7 +314,10 @@ class PostHogJsTest {
             PostHogContext()
         )
         val callback = getCall("init")[1]["before_send"]
-        val captureResult = js("({ event: 'checkout', properties: { distinct_id: 'user-1', email: 'person@example.com', plan: 'paid' } })")
+        val captureResult = js(
+            "({ event: 'checkout', properties: { distinct_id: 'user-1', email: 'person@example.com', " +
+                "plan: 'paid', nullable: null, nested: [['one'], ['two']], date: new Date(0) } })"
+        )
 
         val result = callback(captureResult)
 
@@ -320,8 +325,35 @@ class PostHogJsTest {
         assertEquals("anonymous", result.properties.distinct_id as String)
         assertNull(result.properties.email)
         assertEquals("paid", result.properties.plan as String)
+        assertTrue(hasOwnProperty(result.properties, "nullable"))
+        assertNull(result.properties.nullable)
+        assertEquals("two", readNestedArrayString(result.properties, "nested", 1, 0))
+        assertEquals(0.0, readDateTime(result.properties, "date"))
         assertNull(callback(js("({ event: 'checkout', properties: {} })")))
         assertNull(callback(js("({ properties: { distinct_id: 'user-1' } })")))
+    }
+
+    @Test
+    fun testBeforeSendContainsCallbackAndConversionExceptions() {
+        fakeJs.init = { _: String, options: dynamic ->
+            calledMethods.add("init" to arrayOf<dynamic>(options))
+        }
+        PostHog.setup(
+            PostHogConfig(
+                apiKey = "key",
+                beforeSend = listOf(
+                    PostHogBeforeSend { throw IllegalStateException("failed") },
+                    PostHogBeforeSend { it.copy(event = "continued") }
+                )
+            ),
+            PostHogContext()
+        )
+        val callback = getCall("init")[0]["before_send"]
+
+        val result = callback(js("({ event: 'checkout', properties: { distinct_id: 'user-1' } })"))
+
+        assertEquals("continued", result.event as String)
+        assertNull(callback(createThrowingCaptureResult()))
     }
 
     @Test
@@ -394,3 +426,11 @@ class PostHogJsTest {
         assertEquals(true, call[1]["first_login"] as Boolean)
     }
 }
+
+private fun hasOwnProperty(target: dynamic, key: String): Boolean =
+    js("Object.prototype.hasOwnProperty.call(target, key)")
+private fun readNestedArrayString(target: dynamic, key: String, outerIndex: Int, innerIndex: Int): String =
+    js("target[key][outerIndex][innerIndex]")
+private fun readDateTime(target: dynamic, key: String): Double = js("target[key].getTime()")
+private fun createThrowingCaptureResult(): dynamic =
+    js("new Proxy({ event: 'checkout' }, { get(target, key) { if (key === 'properties') throw new Error('failed'); return target[key]; } })")

--- a/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
+++ b/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
@@ -297,8 +297,7 @@ class PostHogJsTest {
             calledMethods.add("init" to arrayOf<dynamic>(apiKey, options))
         }
         PostHog.setup(
-            PostHogConfig(
-                apiKey = "key",
+            PostHogConfig(apiKey = "key").apply {
                 beforeSend = listOf(
                     PostHogBeforeSend {
                         it.copy(
@@ -308,7 +307,7 @@ class PostHogJsTest {
                         )
                     }
                 )
-            ),
+            },
             PostHogContext()
         )
         val callback = getCall("init")[1]["before_send"]
@@ -320,6 +319,8 @@ class PostHogJsTest {
         assertEquals("anonymous", result.properties.distinct_id as String)
         assertNull(result.properties.email)
         assertEquals("paid", result.properties.plan as String)
+        assertNull(callback(js("({ event: 'checkout', properties: {} })")))
+        assertNull(callback(js("({ properties: { distinct_id: 'user-1' } })")))
     }
 
     @Test

--- a/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
+++ b/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
@@ -292,6 +292,37 @@ class PostHogJsTest {
     }
 
     @Test
+    fun testSetupMapsBeforeSendToPostHogJs() {
+        fakeJs.init = { apiKey: String, options: dynamic ->
+            calledMethods.add("init" to arrayOf<dynamic>(apiKey, options))
+        }
+        PostHog.setup(
+            PostHogConfig(
+                apiKey = "key",
+                beforeSend = listOf(
+                    PostHogBeforeSend {
+                        it.copy(
+                            event = "sanitized",
+                            distinctId = "anonymous",
+                            properties = it.properties - "email"
+                        )
+                    }
+                )
+            ),
+            PostHogContext()
+        )
+        val callback = getCall("init")[1]["before_send"]
+        val captureResult = js("({ event: 'checkout', properties: { distinct_id: 'user-1', email: 'person@example.com', plan: 'paid' } })")
+
+        val result = callback(captureResult)
+
+        assertEquals("sanitized", result.event as String)
+        assertEquals("anonymous", result.properties.distinct_id as String)
+        assertNull(result.properties.email)
+        assertEquals("paid", result.properties.plan as String)
+    }
+
+    @Test
     fun testGetFeatureFlagResultRoutesCorrectly() {
         PostHog.getFeatureFlagResult("test_flag")
         val call = getCall("getFeatureFlagResult")

--- a/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
+++ b/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
@@ -297,7 +297,8 @@ class PostHogJsTest {
             calledMethods.add("init" to arrayOf<dynamic>(apiKey, options))
         }
         PostHog.setup(
-            PostHogConfig(apiKey = "key").apply {
+            PostHogConfig(
+                apiKey = "key",
                 beforeSend = listOf(
                     PostHogBeforeSend {
                         it.copy(
@@ -307,7 +308,7 @@ class PostHogJsTest {
                         )
                     }
                 )
-            },
+            ),
             PostHogContext()
         )
         val callback = getCall("init")[1]["before_send"]

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -8,6 +8,26 @@ internal var postHogInstance: PostHogInterface? = null
 
 internal const val SDK_NAME = "posthog-kmp"
 
+internal fun com.posthog.PostHogConfig.configureBeforeSend(config: PostHogConfig) {
+    if (config.beforeSend.isEmpty()) return
+
+    addBeforeSend { event ->
+        config.runBeforeSend(
+            PostHogEvent(
+                event = event.event,
+                distinctId = event.distinctId,
+                properties = event.properties.orEmpty()
+            )
+        )?.let { processed ->
+            event.copy(
+                event = processed.event,
+                distinctId = processed.distinctId,
+                properties = processed.properties.toMutableMap()
+            )
+        }
+    }
+}
+
 internal actual fun platformCapture(
     event: String,
     properties: Map<String, Any>?,

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -17,12 +17,17 @@ internal fun com.posthog.PostHogConfig.configureBeforeSend(config: PostHogConfig
                 event = event.event,
                 distinctId = event.distinctId,
                 properties = event.properties.orEmpty()
-            )
+            ),
+            onError = {
+                if (config.debug) logger.log("Before-send callback failed and was ignored.")
+            }
         )?.let { processed ->
             event.copy(
                 event = processed.event,
                 distinctId = processed.distinctId,
-                properties = processed.properties.toMutableMap()
+                properties = processed.properties.mapNotNull { (key, value) ->
+                    value?.let { key to it }
+                }.toMap().toMutableMap()
             )
         }
     }

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHog.jvm.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHog.jvm.kt
@@ -32,6 +32,7 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         optOut = config.optOut
 
         personProfiles = config.personProfiles.toCorePersonProfiles()
+        configureBeforeSend(config)
     }
 
     val home = System.getProperty("user.home")?.takeIf { it.isNotBlank() }

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -208,8 +208,7 @@ class PostHogJvmTest {
 
     @Test
     fun testBeforeSendDelegatesToNativeConfigAndPreservesMetadata() {
-        val wrapperConfig = PostHogConfig(
-            apiKey = "key",
+        val wrapperConfig = PostHogConfig(apiKey = "key").apply {
             beforeSend = listOf(
                 PostHogBeforeSend {
                     it.copy(
@@ -219,7 +218,7 @@ class PostHogJvmTest {
                     )
                 }
             )
-        )
+        }
         val nativeConfig = com.posthog.PostHogConfig(apiKey = "key")
         nativeConfig.configureBeforeSend(wrapperConfig)
         val timestamp = Date(1234)

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -208,7 +208,8 @@ class PostHogJvmTest {
 
     @Test
     fun testBeforeSendDelegatesToNativeConfigAndPreservesMetadata() {
-        val wrapperConfig = PostHogConfig(apiKey = "key").apply {
+        val wrapperConfig = PostHogConfig(
+            apiKey = "key",
             beforeSend = listOf(
                 PostHogBeforeSend {
                     it.copy(
@@ -218,7 +219,7 @@ class PostHogJvmTest {
                     )
                 }
             )
-        }
+        )
         val nativeConfig = com.posthog.PostHogConfig(apiKey = "key")
         nativeConfig.configureBeforeSend(wrapperConfig)
         val timestamp = Date(1234)

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -1,5 +1,7 @@
 package com.posthog.kmp
 
+import java.util.Date
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -202,5 +204,42 @@ class PostHogJvmTest {
     fun testSetPersonPropertiesRoutesCorrectly() {
         PostHog.setPersonProperties(mapOf("plan" to "premium"), mapOf("first_login" to true))
         assertMethodCalled("setPersonProperties", mapOf("plan" to "premium"), mapOf("first_login" to true))
+    }
+
+    @Test
+    fun testBeforeSendDelegatesToNativeConfigAndPreservesMetadata() {
+        val wrapperConfig = PostHogConfig(
+            apiKey = "key",
+            beforeSend = listOf(
+                PostHogBeforeSend {
+                    it.copy(
+                        event = "sanitized",
+                        distinctId = "anonymous",
+                        properties = it.properties - "email"
+                    )
+                }
+            )
+        )
+        val nativeConfig = com.posthog.PostHogConfig(apiKey = "key")
+        nativeConfig.configureBeforeSend(wrapperConfig)
+        val timestamp = Date(1234)
+        val uuid = UUID.randomUUID()
+
+        val result = nativeConfig.beforeSendList.single().run(
+            com.posthog.PostHogEvent(
+                event = "checkout",
+                distinctId = "user-1",
+                properties = mutableMapOf("email" to "person@example.com", "plan" to "paid"),
+                timestamp = timestamp,
+                uuid = uuid
+            )
+        )
+
+        assertEquals("sanitized", result?.event)
+        assertEquals("anonymous", result?.distinctId)
+        assertEquals("paid", result?.properties?.get("plan"))
+        assertEquals(false, result?.properties?.containsKey("email"))
+        assertEquals(timestamp, result?.timestamp)
+        assertEquals(uuid, result?.uuid)
     }
 }

--- a/posthog-kmp/src/swift/PostHogBridge/PostHogBridge.swift
+++ b/posthog-kmp/src/swift/PostHogBridge/PostHogBridge.swift
@@ -37,7 +37,8 @@ import PostHog
         sessionRecordingCaptureLogs: Bool = false,
         sessionRecordingScreenshotMode: Bool = false,
         autocapture: Bool = false,
-        sdkVersion: String = "unknown"
+        sdkVersion: String = "unknown",
+        beforeSend: ((NSDictionary) -> NSDictionary?)? = nil
     ) {
         let config = PostHogConfig(apiKey: apiKey, host: host)
 
@@ -78,6 +79,28 @@ import PostHog
         }
 
         #endif
+
+        if let beforeSend {
+            config.setBeforeSend { event in
+                let transformed = beforeSend([
+                    "event": event.event,
+                    "distinctId": event.distinctId,
+                    "properties": event.properties,
+                ])
+                guard let transformed else { return nil }
+
+                if let eventName = transformed["event"] as? String {
+                    event.event = eventName
+                }
+                if let distinctId = transformed["distinctId"] as? String {
+                    event.distinctId = distinctId
+                }
+                if let properties = transformed["properties"] as? [String: Any] {
+                    event.properties = properties
+                }
+                return event
+            }
+        }
 
         postHogSdkName = "posthog-kmp"
         postHogVersion = sdkVersion

--- a/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
+++ b/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
@@ -191,7 +191,7 @@ private fun JsAny.toFeatureFlagResult(): FeatureFlagResult? {
 
 private fun processBeforeSend(config: PostHogConfig, captureResult: JsAny?): JsAny? {
     captureResult ?: return null
-    val event = captureResult.toPostHogEvent() ?: return captureResult
+    val event = captureResult.toPostHogEvent() ?: return null
     val processed = config.runBeforeSend(event) ?: return null
 
     val processedProperties = processed.properties.toJsObject()

--- a/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
+++ b/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
@@ -191,22 +191,27 @@ private fun JsAny.toFeatureFlagResult(): FeatureFlagResult? {
 
 private fun processBeforeSend(config: PostHogConfig, captureResult: JsAny?): JsAny? {
     captureResult ?: return null
-    val event = captureResult.toPostHogEvent() ?: return null
-    val processed = config.runBeforeSend(event) ?: return null
+    return try {
+        val event = captureResult.toPostHogEvent() ?: return null
+        val processed = config.runBeforeSend(event) {
+            if (config.debug) logWasmError("beforeSend", "callback failed and was ignored")
+        } ?: return null
 
-    val processedProperties = processed.properties.toJsObject()
-    setJsProperty(processedProperties, "distinct_id", processed.distinctId.toJsString())
-    setJsProperty(captureResult, "event", processed.event.toJsString())
-    setJsProperty(captureResult, "properties", processedProperties)
-    return captureResult
+        val processedProperties = processed.properties.toJsObject()
+        setJsProperty(processedProperties, "distinct_id", processed.distinctId.toJsString())
+        setJsProperty(captureResult, "event", processed.event.toJsString())
+        setJsProperty(captureResult, "properties", processedProperties)
+        captureResult
+    } catch (_: Throwable) {
+        if (config.debug) logWasmError("beforeSend", "processing failed; event was dropped")
+        null
+    }
 }
 
 private fun JsAny.toPostHogEvent(): PostHogEvent? {
     val event = getJsProperty(this, "event")?.toKotlinString() ?: return null
     val jsProperties = getJsProperty(this, "properties") ?: return null
-    val properties = jsProperties.toKotlinMap().mapNotNull { (key, value) ->
-        value?.let { key to it }
-    }.toMap()
+    val properties = jsProperties.toKotlinMap()
     val distinctId = properties["distinct_id"] as? String ?: return null
     return PostHogEvent(event, distinctId, properties - "distinct_id")
 }
@@ -295,6 +300,7 @@ private fun Any?.toJsAny(): JsAny? = when (this) {
         (this as Map<String, Any?>).toJsObject()
     }
     is List<*> -> toJsArray()
+    is OpaqueJsValue -> value
     else -> toString().toJsString()
 }
 
@@ -303,16 +309,23 @@ private fun JsAny.toKotlinValue(): Any? = when {
     isJsBoolean(this) -> toKotlinBoolean()
     isJsNumber(this) -> toKotlinDouble()
     isJsArray(this) -> List(jsArrayLength(this)) { index -> jsArrayItem(this, index)?.toKotlinValue() }
-    isJsObject(this) -> toKotlinMap()
-    else -> null
+    isPlainJsObject(this) -> toKotlinMap()
+    else -> OpaqueJsValue(this)
 }
+
+private class OpaqueJsValue(val value: JsAny)
 
 private fun JsAny.toKotlinMap(): Map<String, Any?> {
     val keys = jsObjectKeys(this)
     return buildMap {
         repeat(jsArrayLength(keys)) { index ->
             val key = jsArrayItem(keys, index)?.toKotlinString() ?: return@repeat
-            put(key, getJsProperty(this@toKotlinMap, key)?.toKotlinValue())
+            val value = getJsProperty(this@toKotlinMap, key)
+            if (value != null) {
+                put(key, value.toKotlinValue())
+            } else if (isJsNullProperty(this@toKotlinMap, key)) {
+                put(key, null)
+            }
         }
     }
 }
@@ -335,7 +348,9 @@ private fun isJsArray(value: JsAny): Boolean = js("Array.isArray(value)")
 private fun isJsString(value: JsAny): Boolean = js("typeof value === 'string'")
 private fun isJsBoolean(value: JsAny): Boolean = js("typeof value === 'boolean'")
 private fun isJsNumber(value: JsAny): Boolean = js("typeof value === 'number'")
-private fun isJsObject(value: JsAny): Boolean = js("typeof value === 'object' && value !== null")
+private fun isPlainJsObject(value: JsAny): Boolean =
+    js("typeof value === 'object' && value !== null && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)")
+private fun isJsNullProperty(target: JsAny, key: String): Boolean = js("target[key] === null")
 private fun JsAny.toKotlinString(): String = jsStringValue(this)
 private fun JsAny.toKotlinBoolean(): Boolean = jsBooleanValue(this)
 private fun JsAny.toKotlinDouble(): Double = jsNumberValue(this)

--- a/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
+++ b/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
@@ -25,6 +25,9 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
 
     val bootstrap = createJsObject()
     setJsProperty(options, "bootstrap", bootstrap)
+    if (config.beforeSend.isNotEmpty()) {
+        setBeforeSendCallback(options) { captureResult -> processBeforeSend(config, captureResult) }
+    }
     config.sessionRecording?.takeIf { it.enabled }?.let { configureSessionRecording(options, it) }
 
     PostHogJs.init(config.apiKey, options)
@@ -186,6 +189,28 @@ private fun JsAny.toFeatureFlagResult(): FeatureFlagResult? {
     return FeatureFlagResult(key = key, enabled = enabled, variant = variant, payload = payload)
 }
 
+private fun processBeforeSend(config: PostHogConfig, captureResult: JsAny?): JsAny? {
+    captureResult ?: return null
+    val event = captureResult.toPostHogEvent() ?: return captureResult
+    val processed = config.runBeforeSend(event) ?: return null
+
+    val processedProperties = processed.properties.toJsObject()
+    setJsProperty(processedProperties, "distinct_id", processed.distinctId.toJsString())
+    setJsProperty(captureResult, "event", processed.event.toJsString())
+    setJsProperty(captureResult, "properties", processedProperties)
+    return captureResult
+}
+
+private fun JsAny.toPostHogEvent(): PostHogEvent? {
+    val event = getJsProperty(this, "event")?.toKotlinString() ?: return null
+    val jsProperties = getJsProperty(this, "properties") ?: return null
+    val properties = jsProperties.toKotlinMap().mapNotNull { (key, value) ->
+        value?.let { key to it }
+    }.toMap()
+    val distinctId = properties["distinct_id"] as? String ?: return null
+    return PostHogEvent(event, distinctId, properties - "distinct_id")
+}
+
 internal actual fun platformCaptureException(throwable: Throwable, additionalProperties: Map<String, Any>?) {
     PostHogJs.captureException(
         createJsError(
@@ -299,6 +324,8 @@ private fun createJsError(name: String, message: String, stack: String): JsAny =
     js("Object.assign(new Error(message), { name: name, stack: stack })")
 private fun numberToJsAny(value: Double): JsAny = js("value")
 private fun setJsProperty(target: JsAny, key: String, value: JsAny?): Unit = js("{ target[key] = value; }")
+private fun setBeforeSendCallback(target: JsAny, callback: (JsAny?) -> JsAny?): Unit =
+    js("{ target.before_send = callback; }")
 private fun getJsProperty(target: JsAny, key: String): JsAny? = js("target[key]")
 private fun appendJsArray(target: JsAny, value: JsAny?): Unit = js("{ target.push(value); }")
 private fun jsArrayLength(value: JsAny): Int = js("value.length")

--- a/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
+++ b/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
@@ -55,6 +55,32 @@ class PostHogWasmJsTest {
     }
 
     @Test
+    fun setupMapsBeforeSendToPostHogJs() {
+        PostHog.setup(
+            PostHogConfig(
+                apiKey = "phc_test",
+                beforeSend = listOf(
+                    PostHogBeforeSend {
+                        it.copy(
+                            event = "sanitized",
+                            distinctId = "anonymous",
+                            properties = it.properties - "email"
+                        )
+                    }
+                )
+            ),
+            PostHogContext()
+        )
+
+        val result = invokeBeforeSend(fakePostHog)
+
+        assertEquals("sanitized", readJsString(result, "event"))
+        assertEquals("anonymous", readDeepJsString(result, "properties", "distinct_id"))
+        assertEquals("paid", readDeepJsString(result, "properties", "plan"))
+        assertFalse(hasDeepJsProperty(result, "properties", "email"))
+    }
+
+    @Test
     fun captureConvertsPropertiesGroupsAndTimestamp() {
         PostHog.capture(
             event = "checkout",
@@ -236,3 +262,9 @@ private fun readDeepString(target: PostHogJsApi, parent: String, child: String, 
 private fun readDeepBoolean(target: PostHogJsApi, parent: String, child: String, key: String): Boolean = js("target[parent][child][key]")
 private fun readArrayString(target: PostHogJsApi, parent: String, child: String, index: Int): String = js("target[parent][child][index]")
 private fun readTimestamp(target: PostHogJsApi): Double = js("target.captureOptions.timestamp.getTime()")
+private fun invokeBeforeSend(target: PostHogJsApi): JsAny =
+    js("target.options.before_send({ event: 'checkout', properties: { distinct_id: 'user-1', email: 'person@example.com', plan: 'paid' } })")
+private fun readJsString(target: JsAny, key: String): String = js("target[key]")
+private fun readDeepJsString(target: JsAny, parent: String, key: String): String = js("target[parent][key]")
+private fun hasDeepJsProperty(target: JsAny, parent: String, key: String): Boolean =
+    js("Object.prototype.hasOwnProperty.call(target[parent], key)")

--- a/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
+++ b/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
@@ -58,7 +58,8 @@ class PostHogWasmJsTest {
     @Test
     fun setupMapsBeforeSendToPostHogJs() {
         PostHog.setup(
-            PostHogConfig(apiKey = "phc_test").apply {
+            PostHogConfig(
+                apiKey = "phc_test",
                 beforeSend = listOf(
                     PostHogBeforeSend {
                         it.copy(
@@ -68,7 +69,7 @@ class PostHogWasmJsTest {
                         )
                     }
                 )
-            },
+            ),
             PostHogContext()
         )
 

--- a/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
+++ b/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
@@ -79,8 +79,31 @@ class PostHogWasmJsTest {
         assertEquals("anonymous", readDeepJsString(result, "properties", "distinct_id"))
         assertEquals("paid", readDeepJsString(result, "properties", "plan"))
         assertFalse(hasDeepJsProperty(result, "properties", "email"))
+        assertTrue(hasDeepJsProperty(result, "properties", "nullable"))
+        assertTrue(isDeepJsNull(result, "properties", "nullable"))
+        assertEquals("two", readDeepJsArrayString(result, "properties", "nested", 1, 0))
+        assertEquals(0.0, readDeepJsDateTime(result, "properties", "date"))
         assertNull(invokeBeforeSendWithoutDistinctId(fakePostHog))
         assertNull(invokeBeforeSendWithoutEvent(fakePostHog))
+    }
+
+    @Test
+    fun beforeSendContainsCallbackAndConversionExceptions() {
+        PostHog.setup(
+            PostHogConfig(
+                apiKey = "phc_test",
+                beforeSend = listOf(
+                    PostHogBeforeSend { throw IllegalStateException("failed") },
+                    PostHogBeforeSend { it.copy(event = "continued") }
+                )
+            ),
+            PostHogContext()
+        )
+
+        val result = invokeBeforeSend(fakePostHog)
+
+        assertEquals("continued", readJsString(result, "event"))
+        assertNull(invokeBeforeSendWithThrowingGetter(fakePostHog))
     }
 
     @Test
@@ -265,8 +288,11 @@ private fun readDeepString(target: PostHogJsApi, parent: String, child: String, 
 private fun readDeepBoolean(target: PostHogJsApi, parent: String, child: String, key: String): Boolean = js("target[parent][child][key]")
 private fun readArrayString(target: PostHogJsApi, parent: String, child: String, index: Int): String = js("target[parent][child][index]")
 private fun readTimestamp(target: PostHogJsApi): Double = js("target.captureOptions.timestamp.getTime()")
-private fun invokeBeforeSend(target: PostHogJsApi): JsAny =
-    js("target.options.before_send({ event: 'checkout', properties: { distinct_id: 'user-1', email: 'person@example.com', plan: 'paid' } })")
+private fun invokeBeforeSend(target: PostHogJsApi): JsAny = js(
+    "target.options.before_send({ event: 'checkout', properties: { distinct_id: 'user-1', " +
+        "email: 'person@example.com', plan: 'paid', nullable: null, nested: [['one'], ['two']], " +
+        "date: new Date(0) } })"
+)
 private fun invokeBeforeSendWithoutDistinctId(target: PostHogJsApi): JsAny? =
     js("target.options.before_send({ event: 'checkout', properties: {} })")
 private fun invokeBeforeSendWithoutEvent(target: PostHogJsApi): JsAny? =
@@ -275,3 +301,15 @@ private fun readJsString(target: JsAny, key: String): String = js("target[key]")
 private fun readDeepJsString(target: JsAny, parent: String, key: String): String = js("target[parent][key]")
 private fun hasDeepJsProperty(target: JsAny, parent: String, key: String): Boolean =
     js("Object.prototype.hasOwnProperty.call(target[parent], key)")
+private fun isDeepJsNull(target: JsAny, parent: String, key: String): Boolean = js("target[parent][key] === null")
+private fun readDeepJsArrayString(
+    target: JsAny,
+    parent: String,
+    key: String,
+    outerIndex: Int,
+    innerIndex: Int
+): String = js("target[parent][key][outerIndex][innerIndex]")
+private fun readDeepJsDateTime(target: JsAny, parent: String, key: String): Double =
+    js("target[parent][key].getTime()")
+private fun invokeBeforeSendWithThrowingGetter(target: PostHogJsApi): JsAny? =
+    js("target.options.before_send(new Proxy({}, { get() { throw Error() } }))")

--- a/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
+++ b/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class PostHogWasmJsTest {
@@ -57,8 +58,7 @@ class PostHogWasmJsTest {
     @Test
     fun setupMapsBeforeSendToPostHogJs() {
         PostHog.setup(
-            PostHogConfig(
-                apiKey = "phc_test",
+            PostHogConfig(apiKey = "phc_test").apply {
                 beforeSend = listOf(
                     PostHogBeforeSend {
                         it.copy(
@@ -68,7 +68,7 @@ class PostHogWasmJsTest {
                         )
                     }
                 )
-            ),
+            },
             PostHogContext()
         )
 
@@ -78,6 +78,8 @@ class PostHogWasmJsTest {
         assertEquals("anonymous", readDeepJsString(result, "properties", "distinct_id"))
         assertEquals("paid", readDeepJsString(result, "properties", "plan"))
         assertFalse(hasDeepJsProperty(result, "properties", "email"))
+        assertNull(invokeBeforeSendWithoutDistinctId(fakePostHog))
+        assertNull(invokeBeforeSendWithoutEvent(fakePostHog))
     }
 
     @Test
@@ -264,6 +266,10 @@ private fun readArrayString(target: PostHogJsApi, parent: String, child: String,
 private fun readTimestamp(target: PostHogJsApi): Double = js("target.captureOptions.timestamp.getTime()")
 private fun invokeBeforeSend(target: PostHogJsApi): JsAny =
     js("target.options.before_send({ event: 'checkout', properties: { distinct_id: 'user-1', email: 'person@example.com', plan: 'paid' } })")
+private fun invokeBeforeSendWithoutDistinctId(target: PostHogJsApi): JsAny? =
+    js("target.options.before_send({ event: 'checkout', properties: {} })")
+private fun invokeBeforeSendWithoutEvent(target: PostHogJsApi): JsAny? =
+    js("target.options.before_send({ properties: { distinct_id: 'user-1' } })")
 private fun readJsString(target: JsAny, key: String): String = js("target[key]")
 private fun readDeepJsString(target: JsAny, parent: String, key: String): String = js("target[parent][key]")
 private fun hasDeepJsProperty(target: JsAny, parent: String, key: String): Boolean =

--- a/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.posthog.kmp.PostHog
+import com.posthog.kmp.PostHogBeforeSend
 import com.posthog.kmp.PostHogConfig
 import com.posthog.kmp.PostHogContext
 
@@ -94,7 +95,20 @@ fun App(postHogContext: PostHogContext) {
                                 config = PostHogConfig(
                                     apiKey = apiKey,
                                     debug = true,
-                                ),
+                                ).apply {
+                                    beforeSend = listOf(
+                                        PostHogBeforeSend { event ->
+                                            if (event.event == "before_send_drop_test") {
+                                                null
+                                            } else {
+                                                event.copy(
+                                                    properties = event.properties - "sensitive" +
+                                                        ("before_send_applied" to true)
+                                                )
+                                            }
+                                        }
+                                    )
+                                },
                                 context = postHogContext
                             )
                             statusMessage = if (isInitialized) {
@@ -128,13 +142,19 @@ fun App(postHogContext: PostHogContext) {
                     singleLine = true
                 )
 
+                Text(
+                    text = "The sample removes the sensitive property and drops events named before_send_drop_test.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+
                 Button(
                     onClick = {
                         PostHog.capture(
                             event = eventName,
                             properties = mapOf(
                                 "source" to "sample_app",
-                                "platform" to getPlatformName()
+                                "platform" to getPlatformName(),
+                                "sensitive" to "remove_before_send"
                             )
                         )
                         statusMessage = "Event '$eventName' captured!"
@@ -143,6 +163,20 @@ fun App(postHogContext: PostHogContext) {
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text("Capture Event")
+                }
+
+                Button(
+                    onClick = {
+                        PostHog.capture(
+                            event = "before_send_drop_test",
+                            properties = mapOf("source" to "sample_app")
+                        )
+                        statusMessage = "Before-send drop test triggered!"
+                    },
+                    enabled = isInitialized,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Capture Dropped Event")
                 }
 
                 Button(

--- a/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
@@ -95,7 +95,6 @@ fun App(postHogContext: PostHogContext) {
                                 config = PostHogConfig(
                                     apiKey = apiKey,
                                     debug = true,
-                                ).apply {
                                     beforeSend = listOf(
                                         PostHogBeforeSend { event ->
                                             if (event.event == "before_send_drop_test") {
@@ -108,7 +107,7 @@ fun App(postHogContext: PostHogContext) {
                                             }
                                         }
                                     )
-                                },
+                                ),
                                 context = postHogContext
                             )
                             statusMessage = if (isInitialized) {


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog KMP users cannot remove sensitive properties or drop events before a native SDK queues them. Server-side transformations happen after the data leaves the device, so they do not support client-side data minimization.

This adds a common synchronous callback that can change an event or return `null` to drop it. The callback delegates to the native before-send APIs on Android, iOS, JVM, JS, and Wasm. Native metadata such as timestamps and UUIDs remains unchanged. Malformed platform events are dropped so configured privacy callbacks cannot be bypassed.

The callback list is a property on `PostHogConfig` rather than a constructor parameter. This preserves the existing generated constructor and `copy` binary signatures for precompiled consumers.

Closes #51.

## :green_heart: How did you test it?

- `./gradlew detekt`
- `./gradlew :posthog-kmp:jvmTest :posthog-kmp:testAndroid :posthog-kmp:jsNodeTest :posthog-kmp:wasmJsBrowserTest :posthog-kmp:compileKotlinIosArm64 --no-daemon`
- Compared the JVM `PostHogConfig` constructor and `copy` signatures against `origin/main` with `javap`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent implemented the common API and platform adapters in a dedicated worktree. Pi autoreview checked the latest committed branch against `origin/main` and reported no actionable findings. No public session transcript was created.
