### PR TITLE
test: verify SDK timestamps use UTC

### DIFF
--- a/.changeset/busy-lies-marry.md
+++ b/.changeset/busy-lies-marry.md
@@ -1,5 +1,0 @@
----
-"posthog-kmp": patch
----
-
-Document capture timestamps as UTC instants and add cross-platform regression coverage.

--- a/.changeset/busy-lies-marry.md
+++ b/.changeset/busy-lies-marry.md
@@ -1,0 +1,5 @@
+---
+"posthog-kmp": patch
+---
+
+Document capture timestamps as UTC instants and add cross-platform regression coverage.

--- a/posthog-kmp/build.gradle.kts
+++ b/posthog-kmp/build.gradle.kts
@@ -132,10 +132,16 @@ kotlin {
         val iosMain by creating {
             dependsOn(commonMain)
         }
+        val iosTest by creating {
+            dependsOn(commonTest)
+        }
 
         val iosX64Main by getting { dependsOn(iosMain) }
+        getByName("iosX64Test") { dependsOn(iosTest) }
         val iosArm64Main by getting { dependsOn(iosMain) }
+        getByName("iosArm64Test") { dependsOn(iosTest) }
         val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+        getByName("iosSimulatorArm64Test") { dependsOn(iosTest) }
 
         val jsMain by getting {
             dependencies {

--- a/posthog-kmp/src/androidHostTest/kotlin/com/posthog/kmp/PostHogAndroidTest.kt
+++ b/posthog-kmp/src/androidHostTest/kotlin/com/posthog/kmp/PostHogAndroidTest.kt
@@ -1,5 +1,8 @@
 package com.posthog.kmp
 
+import java.time.OffsetDateTime
+import java.util.Date
+import java.util.TimeZone
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -50,6 +53,24 @@ class PostHogAndroidTest {
             null,
             mapOf("company" to "acme")
         )
+    }
+
+    @Test
+    fun testCapturePreservesTimestampInstantAcrossDefaultTimeZones() {
+        val originalTimeZone = TimeZone.getDefault()
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Honolulu"))
+            val timestamp = OffsetDateTime.parse("2024-01-01T17:04:05.678-10:00")
+                .toInstant()
+                .toEpochMilli()
+
+            PostHog.capture("test_event", options = CaptureOptions(timestamp = timestamp))
+
+            assertMethodCalled("capture", "test_event", null, null, null, null, null, Date(timestamp))
+            assertEquals("2024-01-02T03:04:05.678Z", Date(timestamp).toInstant().toString())
+        } finally {
+            TimeZone.setDefault(originalTimeZone)
+        }
     }
 
     @Test

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogModels.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogModels.kt
@@ -4,7 +4,10 @@ package com.posthog.kmp
  * Options for capturing events.
  *
  * @property groups Groups to associate with this event
- * @property timestamp Custom timestamp for the event (defaults to now)
+ * @property timestamp Custom event time as Unix epoch milliseconds, representing a UTC instant
+ *   (defaults to now). UTC is preferred when deriving this value from a date and time; resolve any
+ *   non-UTC offset to the equivalent instant before converting it to epoch milliseconds. Platform
+ *   bridges preserve this instant when constructing their native date type.
  */
 public data class CaptureOptions(
     val groups: Map<String, String>? = null,

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -88,9 +88,11 @@ internal actual fun platformCapture(
         event,
         properties = properties as? Map<Any?, *>,
         groups = groups as? Map<Any?, *>,
-        timestamp = timestamp?.let { NSDate.dateWithTimeIntervalSince1970(it.toDouble() / 1000.0) }
+        timestamp = timestamp?.toNSDate()
     )
 }
+
+internal fun Long.toNSDate(): NSDate = NSDate.dateWithTimeIntervalSince1970(toDouble() / 1000.0)
 
 internal actual fun platformScreen(screenName: String, properties: Map<String, Any>?) {
     @Suppress("UNCHECKED_CAST")

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/PostHogIosTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/PostHogIosTest.kt
@@ -1,0 +1,25 @@
+package com.posthog.kmp
+
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSLocale
+import platform.Foundation.NSTimeZone
+import platform.Foundation.timeZoneForSecondsFromGMT
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PostHogIosTest {
+
+    @Test
+    fun testTimestampConversionPreservesUtcInstant() {
+        val timestamp = 1_704_164_645_678L
+
+        val date = timestamp.toNSDate()
+
+        val formatter = NSDateFormatter().apply {
+            locale = NSLocale(localeIdentifier = "en_US_POSIX")
+            timeZone = NSTimeZone.timeZoneForSecondsFromGMT(0)
+            dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        }
+        assertEquals("2024-01-02T03:04:05.678Z", formatter.stringFromDate(date))
+    }
+}

--- a/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
+++ b/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
@@ -152,6 +152,18 @@ class PostHogJsTest {
     }
 
     @Test
+    fun testCapturePreservesTimestampAsUtcInstant() {
+        PostHog.capture(
+            "test_event",
+            options = CaptureOptions(timestamp = 1_704_164_645_678)
+        )
+
+        val timestamp = getCall("capture")[2]["timestamp"]
+        assertEquals("2024-01-02T03:04:05.678Z", timestamp.toISOString() as String)
+        assertEquals(1_704_164_645_678.0, timestamp.getTime() as Double)
+    }
+
+    @Test
     fun testCaptureDropsNullPropertyValues() {
         PostHog.capture("test_event", mapOf("keep" to 1, "drop" to null))
         val call = getCall("capture")

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -1,6 +1,8 @@
 package com.posthog.kmp
 
+import java.time.OffsetDateTime
 import java.util.Date
+import java.util.TimeZone
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -52,6 +54,24 @@ class PostHogJvmTest {
             null,
             mapOf("company" to "acme")
         )
+    }
+
+    @Test
+    fun testCapturePreservesTimestampInstantAcrossDefaultTimeZones() {
+        val originalTimeZone = TimeZone.getDefault()
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Honolulu"))
+            val timestamp = OffsetDateTime.parse("2024-01-01T17:04:05.678-10:00")
+                .toInstant()
+                .toEpochMilli()
+
+            PostHog.capture("test_event", options = CaptureOptions(timestamp = timestamp))
+
+            assertMethodCalled("capture", "test_event", null, null, null, null, null, Date(timestamp))
+            assertEquals("2024-01-02T03:04:05.678Z", Date(timestamp).toInstant().toString())
+        } finally {
+            TimeZone.setDefault(originalTimeZone)
+        }
     }
 
     @Test

--- a/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
+++ b/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
@@ -129,6 +129,7 @@ class PostHogWasmJsTest {
         assertEquals("two", readArrayString(fakePostHog, "properties", "items", 1))
         assertEquals("posthog", readDeepString(fakePostHog, "properties", "\$groups", "company"))
         assertEquals(1_700_000_000_000.0, readTimestamp(fakePostHog))
+        assertEquals("2023-11-14T22:13:20.000Z", readTimestampIso(fakePostHog))
     }
 
     @Test
@@ -288,6 +289,7 @@ private fun readDeepString(target: PostHogJsApi, parent: String, child: String, 
 private fun readDeepBoolean(target: PostHogJsApi, parent: String, child: String, key: String): Boolean = js("target[parent][child][key]")
 private fun readArrayString(target: PostHogJsApi, parent: String, child: String, index: Int): String = js("target[parent][child][index]")
 private fun readTimestamp(target: PostHogJsApi): Double = js("target.captureOptions.timestamp.getTime()")
+private fun readTimestampIso(target: PostHogJsApi): String = js("target.captureOptions.timestamp.toISOString()")
 private fun invokeBeforeSend(target: PostHogJsApi): JsAny = js(
     "target.options.before_send({ event: 'checkout', properties: { distinct_id: 'user-1', " +
         "email: 'person@example.com', plan: 'paid', nullable: null, nested: [['one'], ['two']], " +


### PR DESCRIPTION
## :bulb: Motivation and Context

`CaptureOptions.timestamp` is a Unix epoch millisecond value, so it identifies the same UTC instant regardless of the local time zone. The API documentation did not state this clearly, and the platform bridge behavior did not have direct regression coverage.

This change documents the UTC instant contract. Android and JVM tests switch the default time zone to Pacific/Honolulu, convert `2024-01-01T17:04:05.678-10:00` to epoch milliseconds, and verify the native `Date` still represents `2024-01-02T03:04:05.678Z`. The JS test verifies both the ISO UTC value and unchanged epoch milliseconds. The Wasm test now verifies the converted JavaScript `Date` serializes to the expected UTC ISO timestamp.

## :green_heart: How did you test it?

- `./gradlew :posthog-kmp:jvmTest :posthog-kmp:testAndroid :posthog-kmp:jsNodeTest :posthog-kmp:wasmJsBrowserTest --no-daemon --rerun-tasks`
- `./gradlew :posthog-kmp:jvmTest :posthog-kmp:testAndroid :posthog-kmp:jsNodeTest :posthog-kmp:wasmJsBrowserTest detekt --no-daemon`
- `"$HOME/.pi/agent/skills/autoreview/scripts/autoreview" --mode branch --base origin/main`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi prepared the commit and PR from the existing human-directed changes. Pi also ran the focused Gradle tests, detekt, and the isolated Pi autoreview. The change keeps the existing epoch-millisecond API and adds documentation and regression coverage rather than changing timestamp conversion behavior.
