### PR TITLE
feat: add error tracking configuration

### DIFF
--- a/.changeset/chatty-zebras-unite.md
+++ b/.changeset/chatty-zebras-unite.md
@@ -1,5 +1,0 @@
----
-"posthog-kmp": none
----
-
-Released with the parent error tracking configuration change.

--- a/.changeset/chatty-zebras-unite.md
+++ b/.changeset/chatty-zebras-unite.md
@@ -1,0 +1,5 @@
+---
+"posthog-kmp": none
+---
+
+Released with the parent error tracking configuration change.

--- a/.changeset/quiet-cats-open.md
+++ b/.changeset/quiet-cats-open.md
@@ -1,0 +1,5 @@
+---
+"posthog-kmp": minor
+---
+
+Add error tracking configuration with automatic exception capture.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ android-compileSdk = "36"
 compose-multiplatform = "1.11.1"
 androidx-activity-compose = "1.13.0"
 posthog-android = "3.58.0"
+posthog-android-gradle-plugin = "1.4.0"
 # Pure-JVM core that posthog-android is built on (versioned independently of posthog-android)
 posthog-core = "6.29.0"
 okio = "3.18.1"
@@ -38,6 +39,7 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 androidKmpLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
+posthogAndroid = { id = "com.posthog.android", version.ref = "posthog-android-gradle-plugin" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 spmforkmp = { id = "io.github.frankois944.spmForKmp", version.ref = "spmforkmp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }

--- a/posthog-kmp/src/androidMain/kotlin/com/posthog/kmp/PostHog.android.kt
+++ b/posthog-kmp/src/androidMain/kotlin/com/posthog/kmp/PostHog.android.kt
@@ -27,6 +27,7 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         optOut = config.optOut
 
         personProfiles = config.personProfiles.toCorePersonProfiles()
+        configureErrorTracking(config.errorTracking)
         configureBeforeSend(config)
 
         config.sessionRecording?.let { sessionConfig ->

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -245,7 +245,9 @@ public data class ErrorTrackingConfig(
      * Console errors remain disabled.
      */
     val autoCapture: Boolean = false,
+    /** Supported on Android, JVM, and iOS. */
     val inAppIncludes: List<String> = emptyList(),
+    /** Supported on Android, JVM, and iOS. */
     val ignoredExceptionTypes: List<KClass<out Throwable>> = emptyList(),
     /** iOS only. */
     val inAppExcludes: List<String> = emptyList(),

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -1,5 +1,7 @@
 package com.posthog.kmp
 
+import kotlin.reflect.KClass
+
 /**
  * Configuration options for PostHog SDK initialization.
  *
@@ -228,10 +230,20 @@ public enum class PersonProfiles {
  *
  * @property autoCapture Automatically capture unhandled exceptions
  * @property inAppIncludes Additional package or bundle prefixes to mark as in-app frames (Android/JVM/iOS)
+ * @property ignoredExceptionTypes Throwable types that should not be captured
+ * @property inAppExcludes Package or bundle prefixes to mark as external frames (iOS only)
+ * @property inAppByDefault Whether unmatched stack frames should be considered in-app (iOS only)
+ *
+ * TODO: Add exceptionSteps when PostHog.addExceptionStep is available in the common API.
  */
 public data class ErrorTrackingConfig(
     val autoCapture: Boolean = false,
-    val inAppIncludes: List<String> = emptyList()
+    val inAppIncludes: List<String> = emptyList(),
+    val ignoredExceptionTypes: List<KClass<out Throwable>> = emptyList(),
+    /** iOS only. */
+    val inAppExcludes: List<String> = emptyList(),
+    /** iOS only. */
+    val inAppByDefault: Boolean = true
 )
 
 /**

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -236,8 +236,6 @@ public enum class PersonProfiles {
  *
  * TODO: Add exceptionSteps when PostHog.addExceptionStep is available in the common API.
  * TODO: Add support for configuring individual Web exception autocapture sources.
- * TODO: Normalize iOS Kotlin/Native stack traces with NSExceptionKt; see
- * https://github.com/PostHog/posthog-kmp/issues/57.
  */
 public data class ErrorTrackingConfig(
     /**

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -235,8 +235,15 @@ public enum class PersonProfiles {
  * @property inAppByDefault Whether unmatched stack frames should be considered in-app (iOS only)
  *
  * TODO: Add exceptionSteps when PostHog.addExceptionStep is available in the common API.
+ * TODO: Add support for configuring individual Web exception autocapture sources.
  */
 public data class ErrorTrackingConfig(
+    /**
+     * Automatically capture unhandled exceptions.
+     *
+     * On Web, enabling this captures unhandled errors and unhandled promise rejections.
+     * Console errors remain disabled.
+     */
     val autoCapture: Boolean = false,
     val inAppIncludes: List<String> = emptyList(),
     val ignoredExceptionTypes: List<KClass<out Throwable>> = emptyList(),

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -20,6 +20,7 @@ package com.posthog.kmp
  * @property sessionRecording Enable session recording (platform dependent)
  * @property autocapture Enable automatic event capture (platform dependent)
  * @property beforeSend Synchronous callbacks that can modify or drop events before they are queued
+ * @property errorTracking Error tracking configuration (platform dependent)
  */
 public data class PostHogConfig(
     val apiKey: String,
@@ -38,8 +39,49 @@ public data class PostHogConfig(
     val personProfiles: PersonProfiles = PersonProfiles.IDENTIFIED_ONLY,
     val sessionRecording: SessionRecordingConfig? = null,
     val autocapture: Boolean = false,
-    val beforeSend: List<PostHogBeforeSend> = emptyList()
+    val beforeSend: List<PostHogBeforeSend> = emptyList(),
+    val errorTracking: ErrorTrackingConfig? = null
 ) {
+    @Deprecated("Retained for binary compatibility", level = DeprecationLevel.HIDDEN)
+    public constructor(
+        apiKey: String,
+        host: String = "https://us.i.posthog.com",
+        debug: Boolean = false,
+        captureApplicationLifecycleEvents: Boolean = true,
+        captureScreenViews: Boolean = false,
+        captureDeepLinks: Boolean = true,
+        sendFeatureFlagEvent: Boolean = true,
+        preloadFeatureFlags: Boolean = true,
+        flushAt: Int = 20,
+        flushIntervalSeconds: Int = 30,
+        maxQueueSize: Int = 1000,
+        maxBatchSize: Int = 50,
+        optOut: Boolean = false,
+        personProfiles: PersonProfiles = PersonProfiles.IDENTIFIED_ONLY,
+        sessionRecording: SessionRecordingConfig? = null,
+        autocapture: Boolean = false,
+        beforeSend: List<PostHogBeforeSend> = emptyList()
+    ) : this(
+        apiKey = apiKey,
+        host = host,
+        debug = debug,
+        captureApplicationLifecycleEvents = captureApplicationLifecycleEvents,
+        captureScreenViews = captureScreenViews,
+        captureDeepLinks = captureDeepLinks,
+        sendFeatureFlagEvent = sendFeatureFlagEvent,
+        preloadFeatureFlags = preloadFeatureFlags,
+        flushAt = flushAt,
+        flushIntervalSeconds = flushIntervalSeconds,
+        maxQueueSize = maxQueueSize,
+        maxBatchSize = maxBatchSize,
+        optOut = optOut,
+        personProfiles = personProfiles,
+        sessionRecording = sessionRecording,
+        autocapture = autocapture,
+        beforeSend = beforeSend,
+        errorTracking = null
+    )
+
     @Deprecated("Retained for binary compatibility", level = DeprecationLevel.HIDDEN)
     public constructor(
         apiKey: String,
@@ -75,7 +117,48 @@ public data class PostHogConfig(
         personProfiles = personProfiles,
         sessionRecording = sessionRecording,
         autocapture = autocapture,
-        beforeSend = emptyList()
+        beforeSend = emptyList(),
+        errorTracking = null
+    )
+
+    @Deprecated("Retained for binary compatibility", level = DeprecationLevel.HIDDEN)
+    public fun copy(
+        apiKey: String = this.apiKey,
+        host: String = this.host,
+        debug: Boolean = this.debug,
+        captureApplicationLifecycleEvents: Boolean = this.captureApplicationLifecycleEvents,
+        captureScreenViews: Boolean = this.captureScreenViews,
+        captureDeepLinks: Boolean = this.captureDeepLinks,
+        sendFeatureFlagEvent: Boolean = this.sendFeatureFlagEvent,
+        preloadFeatureFlags: Boolean = this.preloadFeatureFlags,
+        flushAt: Int = this.flushAt,
+        flushIntervalSeconds: Int = this.flushIntervalSeconds,
+        maxQueueSize: Int = this.maxQueueSize,
+        maxBatchSize: Int = this.maxBatchSize,
+        optOut: Boolean = this.optOut,
+        personProfiles: PersonProfiles = this.personProfiles,
+        sessionRecording: SessionRecordingConfig? = this.sessionRecording,
+        autocapture: Boolean = this.autocapture,
+        beforeSend: List<PostHogBeforeSend> = this.beforeSend
+    ): PostHogConfig = PostHogConfig(
+        apiKey = apiKey,
+        host = host,
+        debug = debug,
+        captureApplicationLifecycleEvents = captureApplicationLifecycleEvents,
+        captureScreenViews = captureScreenViews,
+        captureDeepLinks = captureDeepLinks,
+        sendFeatureFlagEvent = sendFeatureFlagEvent,
+        preloadFeatureFlags = preloadFeatureFlags,
+        flushAt = flushAt,
+        flushIntervalSeconds = flushIntervalSeconds,
+        maxQueueSize = maxQueueSize,
+        maxBatchSize = maxBatchSize,
+        optOut = optOut,
+        personProfiles = personProfiles,
+        sessionRecording = sessionRecording,
+        autocapture = autocapture,
+        beforeSend = beforeSend,
+        errorTracking = errorTracking
     )
 
     @Deprecated("Retained for binary compatibility", level = DeprecationLevel.HIDDEN)
@@ -113,7 +196,8 @@ public data class PostHogConfig(
         personProfiles = personProfiles,
         sessionRecording = sessionRecording,
         autocapture = autocapture,
-        beforeSend = beforeSend
+        beforeSend = beforeSend,
+        errorTracking = errorTracking
     )
 
     public companion object {
@@ -138,6 +222,17 @@ public enum class PersonProfiles {
     /** Never create person profiles */
     NEVER
 }
+
+/**
+ * Error tracking configuration options.
+ *
+ * @property autoCapture Automatically capture unhandled exceptions
+ * @property inAppIncludes Additional package or bundle prefixes to mark as in-app frames (Android/JVM/iOS)
+ */
+public data class ErrorTrackingConfig(
+    val autoCapture: Boolean = false,
+    val inAppIncludes: List<String> = emptyList()
+)
 
 /**
  * Session recording configuration options.

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -236,6 +236,8 @@ public enum class PersonProfiles {
  *
  * TODO: Add exceptionSteps when PostHog.addExceptionStep is available in the common API.
  * TODO: Add support for configuring individual Web exception autocapture sources.
+ * TODO: Normalize iOS Kotlin/Native stack traces with NSExceptionKt; see
+ * https://github.com/PostHog/posthog-kmp/issues/57.
  */
 public data class ErrorTrackingConfig(
     /**
@@ -243,6 +245,10 @@ public data class ErrorTrackingConfig(
      *
      * On Web, enabling this captures unhandled errors and unhandled promise rejections.
      * Console errors remain disabled.
+     *
+     * On Android, symbolication of minified frames requires the PostHog Android Gradle plugin
+     * to upload the ProGuard or R8 mappings. On iOS, server-side symbolication requires uploading
+     * the app's debug symbols (dSYMs).
      */
     val autoCapture: Boolean = false,
     /** Supported on Android, JVM, and iOS. */

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogConfig.kt
@@ -253,7 +253,13 @@ public data class ErrorTrackingConfig(
     val autoCapture: Boolean = false,
     /** Supported on Android, JVM, and iOS. */
     val inAppIncludes: List<String> = emptyList(),
-    /** Supported on Android, JVM, and iOS. */
+    /**
+     * Supported on Android, JVM, and iOS.
+     *
+     * Android and JVM match throwable classes through their type hierarchy. iOS matches simple class names,
+     * so classes with the same name in different packages are treated as the same type. Native signal and
+     * Mach exception types cannot be represented by [KClass] and are not filtered by this setting.
+     */
     val ignoredExceptionTypes: List<KClass<out Throwable>> = emptyList(),
     /** iOS only. */
     val inAppExcludes: List<String> = emptyList(),

--- a/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
+++ b/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
@@ -17,6 +17,26 @@ class PostHogConfigTest {
     }
 
     @Test
+    fun defaultsErrorTrackingToNull() {
+        assertNull(PostHogConfig(apiKey = "phc_test").errorTracking)
+    }
+
+    @Test
+    fun errorTrackingDefaultsMatchNativeSdks() {
+        val config = ErrorTrackingConfig()
+        assertEquals(false, config.autoCapture)
+        assertEquals(emptyList(), config.inAppIncludes)
+    }
+
+    @Test
+    fun copyPreservesErrorTracking() {
+        val errorTracking = ErrorTrackingConfig(autoCapture = true, inAppIncludes = listOf("com.example"))
+        val config = PostHogConfig(apiKey = "phc_test", errorTracking = errorTracking)
+
+        assertEquals(errorTracking, config.copy(debug = true).errorTracking)
+    }
+
+    @Test
     fun sessionRecordingDefaultsMatchNativeSdks() {
         val config = SessionRecordingConfig()
         assertEquals(true, config.maskAllTextInputs)

--- a/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
+++ b/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
@@ -6,6 +6,8 @@ import kotlin.test.assertNull
 
 class PostHogConfigTest {
 
+    private class IgnoredException : RuntimeException()
+
     @Test
     fun defaultsToUsCloudHost() {
         assertEquals(PostHogConfig.HOST_US, PostHogConfig(apiKey = "phc_test").host)
@@ -26,11 +28,20 @@ class PostHogConfigTest {
         val config = ErrorTrackingConfig()
         assertEquals(false, config.autoCapture)
         assertEquals(emptyList(), config.inAppIncludes)
+        assertEquals(emptyList(), config.ignoredExceptionTypes)
+        assertEquals(emptyList(), config.inAppExcludes)
+        assertEquals(true, config.inAppByDefault)
     }
 
     @Test
     fun copyPreservesErrorTracking() {
-        val errorTracking = ErrorTrackingConfig(autoCapture = true, inAppIncludes = listOf("com.example"))
+        val errorTracking = ErrorTrackingConfig(
+            autoCapture = true,
+            inAppIncludes = listOf("com.example"),
+            ignoredExceptionTypes = listOf(IgnoredException::class),
+            inAppExcludes = listOf("ThirdParty"),
+            inAppByDefault = false
+        )
         val config = PostHogConfig(apiKey = "phc_test", errorTracking = errorTracking)
 
         assertEquals(errorTracking, config.copy(debug = true).errorTracking)

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/KotlinThrowableNSException.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/KotlinThrowableNSException.kt
@@ -1,0 +1,157 @@
+/*
+ * Stack-address normalization adapted from NSExceptionKt:
+ * https://github.com/rickclephas/NSExceptionKt
+ *
+ * MIT License
+ *
+ * Copyright (c) 2022 Rick Clephas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@file:OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class, UnsafeNumber::class)
+
+package com.posthog.kmp
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.convert
+import platform.Foundation.NSException
+import platform.Foundation.NSLog
+import platform.Foundation.NSNumber
+import platform.darwin.NSUInteger
+import kotlin.concurrent.AtomicInt
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ReportUnhandledExceptionHook
+import kotlin.native.getStackTraceAddresses
+import kotlin.native.setUnhandledExceptionHook
+import kotlin.native.terminateWithUnhandledException
+
+internal fun Throwable.toNSException(appendCauses: Boolean = true): NSException {
+    val addresses = filteredStackTraceAddresses().let { rootAddresses ->
+        if (!appendCauses) return@let rootAddresses
+        buildList {
+            addAll(rootAddresses)
+            for (cause in causes) {
+                addAll(cause.filteredStackTraceAddresses(keepLastConstructor = true, commonAddresses = rootAddresses))
+            }
+        }
+    }.map { NSNumber(unsignedInteger = it.convert<NSUInteger>()) }
+
+    return KotlinThrowableNSException(
+        name = this::class.qualifiedName ?: this::class.simpleName ?: "Throwable",
+        reason = reasonWithCauses(appendCauses),
+        returnAddresses = addresses
+    )
+}
+
+private fun Throwable.reasonWithCauses(appendCauses: Boolean): String? {
+    if (!appendCauses) return message
+    return buildString {
+        message?.let(::append)
+        for (cause in causes) {
+            if (isNotEmpty()) appendLine()
+            append("Caused by: ")
+            append(cause::class.qualifiedName ?: cause::class.simpleName ?: "Throwable")
+            cause.message?.let { append(": $it") }
+        }
+    }.takeIf { it.isNotEmpty() }
+}
+
+internal val Throwable.causes: List<Throwable>
+    get() = buildList {
+        val visited = mutableSetOf<Throwable>()
+        var current = cause
+        while (current != null && visited.add(current)) {
+            add(current)
+            current = current.cause
+        }
+    }
+
+internal fun Throwable.filteredStackTraceAddresses(
+    keepLastConstructor: Boolean = false,
+    commonAddresses: List<Long> = emptyList()
+): List<Long> = getStackTraceAddresses()
+    .dropConstructorAddresses(
+        qualifiedClassName = this::class.qualifiedName ?: Throwable::class.qualifiedName!!,
+        stackTrace = getStackTrace(),
+        keepLast = keepLastConstructor
+    )
+    .dropCommonAddresses(commonAddresses)
+
+internal fun List<Long>.dropConstructorAddresses(
+    qualifiedClassName: String,
+    stackTrace: Array<String>,
+    keepLast: Boolean = false
+): List<Long> {
+    val constructorName = "kfun:$qualifiedClassName#<init>"
+    var dropCount = 0
+    var foundConstructor = false
+
+    for (index in stackTrace.indices) {
+        if (stackTrace[index].contains(constructorName)) {
+            foundConstructor = true
+        } else if (foundConstructor) {
+            dropCount = index
+            break
+        }
+    }
+
+    if (keepLast && dropCount > 0) dropCount--
+    return if (dropCount == 0) this else drop(dropCount)
+}
+
+internal fun List<Long>.dropCommonAddresses(commonAddresses: List<Long>): List<Long> {
+    var index = commonAddresses.size
+    if (index == 0) return this
+    return dropLastWhile { index-- > 0 && commonAddresses[index] == it }
+}
+
+private class KotlinThrowableNSException(
+    name: String,
+    reason: String?,
+    private val returnAddresses: List<NSNumber>
+) : NSException(name, reason, null) {
+    override fun callStackReturnAddresses(): List<NSNumber> = returnAddresses
+}
+
+private val captureUnhandledExceptions = AtomicInt(0)
+private val installedUnhandledExceptionHook = AtomicInt(0)
+
+internal fun configureUnhandledKotlinExceptionCapture(enabled: Boolean, debug: Boolean = false) {
+    captureUnhandledExceptions.value = if (enabled) 1 else 0
+    if (!enabled || !installedUnhandledExceptionHook.compareAndSet(0, 1)) return
+
+    val hook: ReportUnhandledExceptionHook = { throwable ->
+        if (captureUnhandledExceptions.value == 1) {
+            // Raising lets the native crash reporter own capture, metadata, remote configuration, and termination.
+            throwable.toNSException().raise()
+        }
+        terminateWithUnhandledException(throwable)
+    }
+    val previousHook = setUnhandledExceptionHook(hook)
+    if (previousHook != null) {
+        // Raising is non-returning, so preserve an existing hook rather than installing an unchainable wrapper.
+        setUnhandledExceptionHook(previousHook)
+        installedUnhandledExceptionHook.value = 0
+        if (debug) {
+            NSLog("[PostHog] Kotlin crash normalization was not installed because another unhandled-exception hook is active.")
+        }
+    }
+}

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/KotlinThrowableNSException.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/KotlinThrowableNSException.kt
@@ -33,6 +33,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.UnsafeNumber
 import kotlinx.cinterop.convert
 import platform.Foundation.NSException
+import platform.Foundation.NSLock
 import platform.Foundation.NSLog
 import platform.Foundation.NSNumber
 import platform.darwin.NSUInteger
@@ -133,19 +134,33 @@ private class KotlinThrowableNSException(
 
 private val captureUnhandledExceptions = AtomicInt(0)
 private val installedUnhandledExceptionHook = AtomicInt(0)
+private val unhandledExceptionHookLock = NSLock()
+private val unhandledKotlinExceptionHook: ReportUnhandledExceptionHook = { throwable ->
+    if (captureUnhandledExceptions.value == 1) {
+        // Raising lets the native crash reporter own capture, metadata, remote configuration, and termination.
+        throwable.toNSException().raise()
+    }
+    terminateWithUnhandledException(throwable)
+}
 
 internal fun configureUnhandledKotlinExceptionCapture(enabled: Boolean, debug: Boolean = false) {
-    captureUnhandledExceptions.value = if (enabled) 1 else 0
-    if (!enabled || !installedUnhandledExceptionHook.compareAndSet(0, 1)) return
-
-    val hook: ReportUnhandledExceptionHook = { throwable ->
-        if (captureUnhandledExceptions.value == 1) {
-            // Raising lets the native crash reporter own capture, metadata, remote configuration, and termination.
-            throwable.toNSException().raise()
+    unhandledExceptionHookLock.lock()
+    try {
+        captureUnhandledExceptions.value = if (enabled) 1 else 0
+        if (enabled) {
+            installUnhandledKotlinExceptionHook(debug)
+        } else {
+            uninstallUnhandledKotlinExceptionHook()
         }
-        terminateWithUnhandledException(throwable)
+    } finally {
+        unhandledExceptionHookLock.unlock()
     }
-    val previousHook = setUnhandledExceptionHook(hook)
+}
+
+private fun installUnhandledKotlinExceptionHook(debug: Boolean) {
+    if (!installedUnhandledExceptionHook.compareAndSet(0, 1)) return
+
+    val previousHook = setUnhandledExceptionHook(unhandledKotlinExceptionHook)
     if (previousHook != null) {
         // Raising is non-returning, so preserve an existing hook rather than installing an unchainable wrapper.
         setUnhandledExceptionHook(previousHook)
@@ -153,5 +168,15 @@ internal fun configureUnhandledKotlinExceptionCapture(enabled: Boolean, debug: B
         if (debug) {
             NSLog("[PostHog] Kotlin crash normalization was not installed because another unhandled-exception hook is active.")
         }
+    }
+}
+
+private fun uninstallUnhandledKotlinExceptionHook() {
+    if (!installedUnhandledExceptionHook.compareAndSet(1, 0)) return
+
+    val removedHook = setUnhandledExceptionHook(null)
+    if (removedHook !== unhandledKotlinExceptionHook) {
+        // The hook was replaced after installation; put the current owner back.
+        setUnhandledExceptionHook(removedHook)
     }
 }

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -43,6 +43,8 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         sessionRecordingCaptureLogs = sessionConfig?.captureLogs ?: false,
         sessionRecordingScreenshotMode = sessionConfig?.screenshot ?: false,
         autocapture = config.autocapture,
+        errorAutoCapture = config.errorTracking?.autoCapture ?: false,
+        errorTrackingInAppIncludes = config.errorTracking?.inAppIncludes ?: emptyList<String>(),
         sdkVersion = PostHogKmpVersion.VERSION,
         beforeSend = if (config.beforeSend.isEmpty()) {
             null

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -46,7 +46,8 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         errorAutoCapture = config.errorTracking?.autoCapture ?: false,
         errorTrackingInAppIncludes = config.errorTracking?.inAppIncludes ?: emptyList<String>(),
         errorTrackingIgnoredExceptionTypes = config.errorTracking?.ignoredExceptionTypes
-            ?.mapNotNull { it.simpleName } ?: emptyList<String>(),
+            ?.flatMap { listOfNotNull(it.simpleName, it.qualifiedName) }
+            ?.distinct() ?: emptyList<String>(),
         errorTrackingInAppExcludes = config.errorTracking?.inAppExcludes ?: emptyList<String>(),
         errorTrackingInAppByDefault = config.errorTracking?.inAppByDefault ?: true,
         sdkVersion = PostHogKmpVersion.VERSION,
@@ -55,6 +56,10 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         } else {
             { event -> processBeforeSend(config, event) }
         }
+    )
+    configureUnhandledKotlinExceptionCapture(
+        enabled = config.errorTracking?.autoCapture == true,
+        debug = config.debug
     )
 }
 
@@ -110,10 +115,8 @@ internal actual fun platformCaptureException(
     additionalProperties: Map<String, Any>?
 ) {
     @Suppress("UNCHECKED_CAST")
-    PostHogBridge.shared().captureExceptionWithType(
-        type = throwable::class.simpleName ?: "Exception",
-        message = throwable.message,
-        stackTrace = throwable.stackTraceToString(),
+    PostHogBridge.shared().captureExceptionWithException(
+        exception = throwable.toNSException(),
         properties = additionalProperties as? Map<Any?, *>
     )
 }
@@ -236,6 +239,7 @@ internal actual fun platformFlush() {
 }
 
 internal actual fun platformClose() {
+    configureUnhandledKotlinExceptionCapture(false)
     PostHogBridge.shared().close()
 }
 

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -45,6 +45,10 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         autocapture = config.autocapture,
         errorAutoCapture = config.errorTracking?.autoCapture ?: false,
         errorTrackingInAppIncludes = config.errorTracking?.inAppIncludes ?: emptyList<String>(),
+        errorTrackingIgnoredExceptionTypes = config.errorTracking?.ignoredExceptionTypes
+            ?.mapNotNull { it.simpleName } ?: emptyList<String>(),
+        errorTrackingInAppExcludes = config.errorTracking?.inAppExcludes ?: emptyList<String>(),
+        errorTrackingInAppByDefault = config.errorTracking?.inAppByDefault ?: true,
         sdkVersion = PostHogKmpVersion.VERSION,
         beforeSend = if (config.beforeSend.isEmpty()) {
             null

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/KotlinThrowableNSExceptionTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/KotlinThrowableNSExceptionTest.kt
@@ -1,0 +1,89 @@
+package com.posthog.kmp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class KotlinThrowableNSExceptionTest {
+
+    @Test
+    fun convertsThrowableToExceptionWithNativeAddresses() {
+        val exception = IllegalStateException("checkout failed").toNSException(appendCauses = false)
+
+        assertEquals("kotlin.IllegalStateException", exception.name)
+        assertEquals("checkout failed", exception.reason)
+        assertTrue(exception.callStackReturnAddresses.isNotEmpty())
+    }
+
+    @Test
+    fun appendsCauseMessagesAndAddresses() {
+        val cause = IllegalArgumentException("invalid cart")
+        val throwable = IllegalStateException("checkout failed", cause)
+
+        val exception = throwable.toNSException()
+
+        assertEquals(
+            "checkout failed\nCaused by: kotlin.IllegalArgumentException: invalid cart",
+            exception.reason
+        )
+        assertTrue(exception.callStackReturnAddresses.isNotEmpty())
+    }
+
+    @Test
+    fun discoversCausesWithoutLoopingOnCycles() {
+        val cause = MutableCauseThrowable("cause")
+        val throwable = Throwable("root", cause)
+        cause.mutableCause = throwable
+
+        assertEquals(listOf(cause, throwable), throwable.causes)
+    }
+
+    @Test
+    fun dropsConstructorAddresses() {
+        val addresses = listOf<Long>(0, 1, 2, 3, 4, 5)
+        val stackTrace = arrayOf(
+            "kfun:kotlin.Throwable#<init>(kotlin.String?){}",
+            "kfun:kotlin.Exception#<init>(kotlin.String?){}",
+            "kfun:sample.CustomException#<init>(kotlin.String?){}",
+            "kfun:sample.CustomException#<init>(){}",
+            "kfun:sample.Checkout#submit(){}",
+            "kfun:sample.App#main(){}"
+        )
+
+        assertEquals(
+            listOf<Long>(4, 5),
+            addresses.dropConstructorAddresses("sample.CustomException", stackTrace)
+        )
+        assertEquals(
+            listOf<Long>(3, 4, 5),
+            addresses.dropConstructorAddresses("sample.CustomException", stackTrace, keepLast = true)
+        )
+    }
+
+    @Test
+    fun keepsAddressesWhenConstructorIsUnknown() {
+        val addresses = listOf<Long>(0, 1, 2)
+        val stackTrace = arrayOf(
+            "kfun:kotlin.Throwable#<init>(){}",
+            "kfun:sample.App#main(){}"
+        )
+
+        assertSame(addresses, addresses.dropConstructorAddresses("sample.CustomException", stackTrace))
+    }
+
+    @Test
+    fun dropsOnlySharedTailAddresses() {
+        val commonAddresses = listOf<Long>(5, 4, 3, 2, 1, 0)
+        val addresses = listOf<Long>(8, 7, 6, 2, 1, 0)
+
+        assertEquals(listOf<Long>(8, 7, 6), addresses.dropCommonAddresses(commonAddresses))
+        assertSame(addresses, addresses.dropCommonAddresses(emptyList()))
+    }
+
+    private class MutableCauseThrowable(override val message: String) : Throwable() {
+        var mutableCause: Throwable? = null
+        override val cause: Throwable?
+            get() = mutableCause
+    }
+}

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/KotlinThrowableNSExceptionTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/KotlinThrowableNSExceptionTest.kt
@@ -1,7 +1,15 @@
+@file:OptIn(ExperimentalNativeApi::class)
+
 package com.posthog.kmp
 
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ReportUnhandledExceptionHook
+import kotlin.native.getUnhandledExceptionHook
+import kotlin.native.setUnhandledExceptionHook
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -79,6 +87,32 @@ class KotlinThrowableNSExceptionTest {
 
         assertEquals(listOf<Long>(8, 7, 6), addresses.dropCommonAddresses(commonAddresses))
         assertSame(addresses, addresses.dropCommonAddresses(emptyList()))
+    }
+
+    @Test
+    fun releasesOnlyItsOwnUnhandledExceptionHook() {
+        val originalHook = setUnhandledExceptionHook(null)
+        try {
+            configureUnhandledKotlinExceptionCapture(true)
+            val installedHook = assertNotNull(getUnhandledExceptionHook())
+
+            configureUnhandledKotlinExceptionCapture(false)
+            assertNull(getUnhandledExceptionHook())
+
+            configureUnhandledKotlinExceptionCapture(true)
+            assertSame(installedHook, getUnhandledExceptionHook())
+
+            val replacementHook: ReportUnhandledExceptionHook = { _ -> }
+            setUnhandledExceptionHook(replacementHook)
+            configureUnhandledKotlinExceptionCapture(false)
+            assertSame(replacementHook, getUnhandledExceptionHook())
+
+            configureUnhandledKotlinExceptionCapture(true)
+            assertSame(replacementHook, getUnhandledExceptionHook())
+        } finally {
+            configureUnhandledKotlinExceptionCapture(false)
+            setUnhandledExceptionHook(originalHook)
+        }
     }
 
     private class MutableCauseThrowable(override val message: String) : Throwable() {

--- a/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
+++ b/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
@@ -37,6 +37,7 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
     options["capture_pageview"] = config.captureScreenViews
     options["capture_pageleave"] = config.captureScreenViews
     options["autocapture"] = config.autocapture
+    config.errorTracking?.let { options["capture_exceptions"] = it.autoCapture }
     options["persistence"] = "localStorage"
     options["defaults"] = "2026-05-30"
     options["bootstrap"] = js("{}")

--- a/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
+++ b/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
@@ -242,7 +242,9 @@ internal actual fun platformCaptureException(
     throwable: Throwable,
     additionalProperties: Map<String, Any>?
 ) {
-    PostHogJs.captureException(throwable, additionalProperties?.toJsObject())
+    val jsThrowable: dynamic = throwable
+    throwable::class.simpleName?.let { jsThrowable.name = it }
+    PostHogJs.captureException(jsThrowable, additionalProperties?.toJsObject())
 }
 
 internal actual fun platformGetAnonymousId(): String? {

--- a/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
+++ b/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
@@ -396,6 +396,7 @@ class PostHogJsTest {
         PostHog.captureException(throwable, mapOf("context" to "test"))
         val call = getCall("captureException")
         assertEquals(throwable, call[0] as RuntimeException)
+        assertEquals("RuntimeException", call[0].name as String)
         assertEquals("test", call[1]["context"] as String)
     }
 

--- a/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
+++ b/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
@@ -303,6 +303,20 @@ class PostHogJsTest {
         assertEquals("key", call[0] as String)
         assertEquals(true, call[1]["advanced_disable_feature_flags_on_first_load"] as Boolean)
         assertNull(call[1]["advanced_disable_feature_flags"], "flag evaluation must not be disabled permanently")
+        assertNull(call[1]["capture_exceptions"], "error tracking must remain unset unless configured")
+    }
+
+    @Test
+    fun testSetupMapsErrorTrackingToPostHogJs() {
+        fakeJs.init = { apiKey: String, options: dynamic ->
+            calledMethods.add("init" to arrayOf<dynamic>(apiKey, options))
+        }
+        PostHog.setup(
+            PostHogConfig(apiKey = "key", errorTracking = ErrorTrackingConfig(autoCapture = true)),
+            PostHogContext()
+        )
+
+        assertEquals(true, getCall("init")[1]["capture_exceptions"] as Boolean)
     }
 
     @Test

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -8,6 +8,12 @@ internal var postHogInstance: PostHogInterface? = null
 
 internal const val SDK_NAME = "posthog-kmp"
 
+internal fun com.posthog.PostHogConfig.configureErrorTracking(config: ErrorTrackingConfig?) {
+    config ?: return
+    errorTrackingConfig.autoCapture = config.autoCapture
+    errorTrackingConfig.inAppIncludes.addAll(config.inAppIncludes)
+}
+
 internal fun com.posthog.PostHogConfig.configureBeforeSend(config: PostHogConfig) {
     if (config.beforeSend.isEmpty()) return
 

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -12,6 +12,7 @@ internal fun com.posthog.PostHogConfig.configureErrorTracking(config: ErrorTrack
     config ?: return
     errorTrackingConfig.autoCapture = config.autoCapture
     errorTrackingConfig.inAppIncludes.addAll(config.inAppIncludes)
+    errorTrackingConfig.ignoredExceptionTypes.addAll(config.ignoredExceptionTypes.map { it.java })
 }
 
 internal fun com.posthog.PostHogConfig.configureBeforeSend(config: PostHogConfig) {

--- a/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHog.jvm.kt
+++ b/posthog-kmp/src/jvmMain/kotlin/com/posthog/kmp/PostHog.jvm.kt
@@ -32,6 +32,7 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
         optOut = config.optOut
 
         personProfiles = config.personProfiles.toCorePersonProfiles()
+        configureErrorTracking(config.errorTracking)
         configureBeforeSend(config)
     }
 

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -36,11 +36,19 @@ class PostHogJvmTest {
         val nativeConfig = com.posthog.PostHogConfig(apiKey = "key")
 
         nativeConfig.configureErrorTracking(
-            ErrorTrackingConfig(autoCapture = true, inAppIncludes = listOf("com.example"))
+            ErrorTrackingConfig(
+                autoCapture = true,
+                inAppIncludes = listOf("com.example"),
+                ignoredExceptionTypes = listOf(IllegalStateException::class)
+            )
         )
 
         assertEquals(true, nativeConfig.errorTrackingConfig.autoCapture)
         assertEquals(listOf("com.example"), nativeConfig.errorTrackingConfig.inAppIncludes)
+        assertEquals(
+            listOf<Class<out Throwable>>(IllegalStateException::class.java),
+            nativeConfig.errorTrackingConfig.ignoredExceptionTypes
+        )
     }
 
     @Test

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -32,6 +32,18 @@ class PostHogJvmTest {
     }
 
     @Test
+    fun testConfigureErrorTracking() {
+        val nativeConfig = com.posthog.PostHogConfig(apiKey = "key")
+
+        nativeConfig.configureErrorTracking(
+            ErrorTrackingConfig(autoCapture = true, inAppIncludes = listOf("com.example"))
+        )
+
+        assertEquals(true, nativeConfig.errorTrackingConfig.autoCapture)
+        assertEquals(listOf("com.example"), nativeConfig.errorTrackingConfig.inAppIncludes)
+    }
+
+    @Test
     fun testCaptureRoutesCorrectly() {
         PostHog.capture("test_event", mapOf("prop" to "value"))
         assertMethodCalled("capture", "test_event", null, mapOf("prop" to "value"))

--- a/posthog-kmp/src/swift/PostHogBridge/PostHogBridge.swift
+++ b/posthog-kmp/src/swift/PostHogBridge/PostHogBridge.swift
@@ -37,6 +37,8 @@ import PostHog
         sessionRecordingCaptureLogs: Bool = false,
         sessionRecordingScreenshotMode: Bool = false,
         autocapture: Bool = false,
+        errorAutoCapture: Bool = false,
+        errorTrackingInAppIncludes: [String] = [],
         sdkVersion: String = "unknown",
         beforeSend: ((NSDictionary) -> NSDictionary?)? = nil
     ) {
@@ -65,6 +67,8 @@ import PostHog
             config.personProfiles = .identifiedOnly
         }
         config.setDefaultPersonProperties = true
+        config.errorTrackingConfig.autoCapture = errorAutoCapture
+        config.errorTrackingConfig.inAppIncludes.append(contentsOf: errorTrackingInAppIncludes)
 
         #if os(iOS) || targetEnvironment(macCatalyst)
         config.captureElementInteractions = autocapture

--- a/posthog-kmp/src/swift/PostHogBridge/PostHogBridge.swift
+++ b/posthog-kmp/src/swift/PostHogBridge/PostHogBridge.swift
@@ -144,33 +144,12 @@ import PostHog
         }
     }
 
-    /// Capture an exception originating from Kotlin.
-    ///
-    /// The native iOS SDK builds `$exception_list` from native (symbolicated) stack frames and
-    /// cannot consume a Kotlin/Native textual stack as real frames. To avoid discarding the
-    /// Kotlin stack, it is forwarded as the `$exception_stack_trace_raw` property so it lands on
-    /// the `$exception` event alongside the type and message.
-    ///
-    /// - Parameters:
-    ///   - type: The Kotlin throwable's class name (used as the NSException name).
-    ///   - message: The Kotlin throwable's message, if any.
-    ///   - stackTrace: The Kotlin stack trace (`Throwable.stackTraceToString()`).
-    ///   - properties: Optional additional properties to attach to the event.
+    /// Capture an exception originating from Kotlin with its native stack addresses.
     @objc public func captureException(
-        type: String,
-        message: String?,
-        stackTrace: String,
+        exception: NSException,
         properties: NSDictionary?
     ) {
-        let exception = NSException(
-            name: NSExceptionName(rawValue: type),
-            reason: message,
-            userInfo: nil
-        )
-
-        var props = properties as? [String: Any] ?? [:]
-        props["$exception_stack_trace_raw"] = stackTrace
-
+        let props = properties as? [String: Any]
         PostHogSDK.shared.captureException(exception, properties: props)
     }
 

--- a/posthog-kmp/src/swift/PostHogBridge/PostHogBridge.swift
+++ b/posthog-kmp/src/swift/PostHogBridge/PostHogBridge.swift
@@ -39,6 +39,9 @@ import PostHog
         autocapture: Bool = false,
         errorAutoCapture: Bool = false,
         errorTrackingInAppIncludes: [String] = [],
+        errorTrackingIgnoredExceptionTypes: [String] = [],
+        errorTrackingInAppExcludes: [String] = [],
+        errorTrackingInAppByDefault: Bool = true,
         sdkVersion: String = "unknown",
         beforeSend: ((NSDictionary) -> NSDictionary?)? = nil
     ) {
@@ -69,6 +72,9 @@ import PostHog
         config.setDefaultPersonProperties = true
         config.errorTrackingConfig.autoCapture = errorAutoCapture
         config.errorTrackingConfig.inAppIncludes.append(contentsOf: errorTrackingInAppIncludes)
+        config.errorTrackingConfig.ignoredExceptionTypes.append(contentsOf: errorTrackingIgnoredExceptionTypes)
+        config.errorTrackingConfig.inAppExcludes.append(contentsOf: errorTrackingInAppExcludes)
+        config.errorTrackingConfig.inAppByDefault = errorTrackingInAppByDefault
 
         #if os(iOS) || targetEnvironment(macCatalyst)
         config.captureElementInteractions = autocapture

--- a/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
+++ b/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
@@ -18,6 +18,9 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
     setJsProperty(options, "capture_pageview", config.captureScreenViews.toJsBoolean())
     setJsProperty(options, "capture_pageleave", config.captureScreenViews.toJsBoolean())
     setJsProperty(options, "autocapture", config.autocapture.toJsBoolean())
+    config.errorTracking?.let {
+        setJsProperty(options, "capture_exceptions", it.autoCapture.toJsBoolean())
+    }
     setJsProperty(options, "persistence", "localStorage".toJsString())
     setJsProperty(options, "defaults", "2026-05-30".toJsString())
     setJsProperty(options, "person_profiles", config.personProfiles.postHogValue().toJsString())

--- a/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
+++ b/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
@@ -38,7 +38,8 @@ class PostHogWasmJsTest {
                 optOut = true,
                 personProfiles = PersonProfiles.ALWAYS,
                 sessionRecording = SessionRecordingConfig(captureLogs = true),
-                autocapture = true
+                autocapture = true,
+                errorTracking = ErrorTrackingConfig(autoCapture = true)
             ),
             PostHogContext()
         )
@@ -48,6 +49,7 @@ class PostHogWasmJsTest {
         assertTrue(readNestedBoolean(fakePostHog, "options", "debug"))
         assertTrue(readNestedBoolean(fakePostHog, "options", "capture_pageview"))
         assertTrue(readNestedBoolean(fakePostHog, "options", "autocapture"))
+        assertTrue(readNestedBoolean(fakePostHog, "options", "capture_exceptions"))
         assertTrue(readNestedBoolean(fakePostHog, "options", "advanced_disable_feature_flags_on_first_load"))
         assertEquals("always", readNestedString(fakePostHog, "options", "person_profiles"))
         assertTrue(readDeepBoolean(fakePostHog, "options", "session_recording", "captureLogs"))

--- a/sample/README.md
+++ b/sample/README.md
@@ -6,7 +6,7 @@ The sample runs on Android, iOS, Web, and JVM desktop.
 
 The iOS app target generates dSYMs for Debug and Release builds. Its final `Upload PostHog dSYMs` build phase calls [`scripts/upload-posthog-dsyms.sh`](iosApp/scripts/upload-posthog-dsyms.sh). Uploads are opt-in so normal sample and CI builds do not require PostHog credentials.
 
-Install `posthog-cli` 0.7.7 or newer and authenticate locally:
+Install `posthog-cli` 0.7.12 or newer and authenticate locally:
 
 ```bash
 posthog-cli login

--- a/sample/README.md
+++ b/sample/README.md
@@ -4,7 +4,7 @@ The sample runs on Android, iOS, Web, and JVM desktop.
 
 ## iOS error tracking
 
-The iOS app target generates dSYMs for Debug and Release builds. Its final `Upload PostHog dSYMs` build phase calls [`scripts/upload-posthog-dsyms.sh`](iosApp/scripts/upload-posthog-dsyms.sh). Uploads are opt-in so normal sample and CI builds do not require PostHog credentials.
+The iOS app target generates dSYMs for Debug and Release builds. Its `Upload PostHog dSYMs` post-build action calls [`scripts/upload-posthog-dsyms.sh`](iosApp/scripts/upload-posthog-dsyms.sh) after Xcode finishes generating the dSYM. Uploads are opt-in so normal sample and CI builds do not require PostHog credentials.
 
 Install `posthog-cli` 0.7.12 or newer and authenticate locally:
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -2,6 +2,42 @@
 
 The sample runs on Android, iOS, Web, and JVM desktop.
 
+## iOS error tracking
+
+The iOS app target generates dSYMs for Debug and Release builds. Its final `Upload PostHog dSYMs` build phase calls [`scripts/upload-posthog-dsyms.sh`](iosApp/scripts/upload-posthog-dsyms.sh). Uploads are opt-in so normal sample and CI builds do not require PostHog credentials.
+
+Install `posthog-cli` 0.7.7 or newer and authenticate locally:
+
+```bash
+posthog-cli login
+```
+
+CI can authenticate with `POSTHOG_CLI_HOST`, `POSTHOG_CLI_PROJECT_ID`, and `POSTHOG_CLI_API_KEY`. The API key must be a personal API key with error tracking write and organization read scopes, not the `phc_` project token used by the SDK.
+
+Set `POSTHOG_UPLOAD_DSYMS=1` for a Release build to run the upload phase. To upload a Debug simulator dSYM for an end-to-end test, also set `POSTHOG_UPLOAD_DEBUG_SYMBOLS=1`:
+
+```bash
+./gradlew :sample:linkDebugFrameworkIosSimulatorArm64
+
+POSTHOG_UPLOAD_DSYMS=1 \
+POSTHOG_UPLOAD_DEBUG_SYMBOLS=1 \
+xcodebuild \
+  -project sample/iosApp/iosApp.xcodeproj \
+  -scheme iosApp \
+  -configuration Debug \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  build
+```
+
+Set `POSTHOG_INCLUDE_SOURCE=1` to include source context or `POSTHOG_SKIP_ON_CONFLICT=1` to keep an existing symbol set when its content differs.
+
+To verify crash symbolication:
+
+1. Enter the `phc_` project token and initialize PostHog.
+2. Tap **Crash Sample App**. Run without an attached debugger so the crash reporter receives the crash.
+3. Launch the app again and initialize PostHog with the same token. The SDK processes and sends the pending crash report.
+4. Check the crash and uploaded symbol set in PostHog Error Tracking.
+
 ## JVM desktop
 
 Run the app from Gradle:

--- a/sample/README.md
+++ b/sample/README.md
@@ -95,6 +95,8 @@ Build the macOS release DMG:
 ./gradlew :sample:packageReleaseDmg
 ```
 
+Compose Desktop's default release configuration disables obfuscation, so packaged DMGs retain readable class names, source filenames, and line numbers without uploading a mapping. PostHog KMP does not currently support deobfuscating custom-obfuscated JVM desktop builds because it does not expose the ProGuard map ID required for mapping uploads.
+
 Compose Desktop release distributions use ProGuard and a custom JDK runtime. Apps using PostHog must:
 
 1. Add `jdk.unsupported` to `nativeDistributions.modules`. Gson uses this module to deserialize PostHog queue and API models.

--- a/sample/README.md
+++ b/sample/README.md
@@ -2,6 +2,49 @@
 
 The sample runs on Android, iOS, Web, and JVM desktop.
 
+## Web error tracking
+
+The Kotlin/JS production build generates a minified webpack bundle and source map. Build it, inject PostHog chunk metadata, and upload the source map with:
+
+```bash
+./gradlew :sample:jsBrowserDistribution
+sample/scripts/upload-posthog-sourcemaps.sh
+```
+
+The upload script uses `com.posthog.kmp.sample.web` as the release name and the current Git commit as its version. Override these with `POSTHOG_RELEASE_NAME` and `POSTHOG_RELEASE_VERSION` when needed. CI can authenticate with `POSTHOG_CLI_HOST`, `POSTHOG_CLI_PROJECT_ID`, and `POSTHOG_CLI_API_KEY`.
+
+Serve the injected production assets rather than rebuilding them after upload:
+
+```bash
+python3 -m http.server 8080 --directory sample/build/dist/js/productionExecutable
+```
+
+Enter the `phc_` project token, initialize PostHog, then use **Capture Sample Exception** and **Flush** to verify browser stack-trace demangling in PostHog Error Tracking.
+
+## Android error tracking
+
+Release builds use R8 minification and the PostHog Android Gradle plugin to inject a mapping ID into the APK and upload the generated ProGuard mapping to PostHog. The sample preserves its package prefix and prevents app methods from being inlined into vendor classes because Android evaluates `inAppIncludes` against runtime class names before server-side symbolication.
+
+Install `posthog-cli` 0.7.4 or newer and authenticate locally:
+
+```bash
+posthog-cli login
+./gradlew :sample:androidApp:assembleRelease
+```
+
+CI can authenticate with `POSTHOG_CLI_HOST`, `POSTHOG_CLI_PROJECT_ID`, and `POSTHOG_CLI_API_KEY`. The API key must be a personal API key with error tracking write and organization read scopes, not the `phc_` project token used by the SDK.
+
+To verify symbolication, install the minified release build and run it without an attached debugger:
+
+```bash
+./gradlew :sample:androidApp:installRelease
+```
+
+1. Enter the `phc_` project token and initialize PostHog.
+2. Tap **Capture Sample Exception**, then **Flush**, to test a handled exception, or tap **Crash Sample App** to test an unhandled exception.
+3. After an unhandled exception, launch the app again and initialize PostHog with the same token so the SDK can send the pending crash report.
+4. Check the exception and uploaded mapping in PostHog Error Tracking.
+
 ## iOS error tracking
 
 The iOS app target generates dSYMs for Debug and Release builds. Its `Upload PostHog dSYMs` post-build action calls [`scripts/upload-posthog-dsyms.sh`](iosApp/scripts/upload-posthog-dsyms.sh) after Xcode finishes generating the dSYM. Uploads are opt-in so normal sample and CI builds do not require PostHog credentials.

--- a/sample/androidApp/build.gradle.kts
+++ b/sample/androidApp/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.File
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeCompiler)
@@ -46,4 +48,24 @@ kotlin {
 dependencies {
     implementation(project(":sample"))
     implementation(libs.androidx.activity.compose)
+}
+
+// Mapping generation and map-ID injection remain enabled for every minified build. Upload only when
+// posthog-cli has credentials, so normal builds and CI dry runs do not require PostHog access.
+val hasPostHogEnvironmentCredentials =
+    providers.environmentVariable("POSTHOG_CLI_API_KEY").isPresent &&
+        providers.environmentVariable("POSTHOG_CLI_PROJECT_ID").isPresent
+val hasPostHogDotenvCredentials =
+    providers.environmentVariable("POSTHOG_CLI_DOTENV_FILE").isPresent ||
+        providers.gradleProperty("posthog.dotenvFile").isPresent
+val hasStoredPostHogCredentials = System.getProperty("user.home")
+    ?.let { File(it, ".posthog/credentials.json").isFile }
+    ?: false
+val postHogUploadEnabled =
+    hasPostHogEnvironmentCredentials ||
+        hasPostHogDotenvCredentials ||
+        (!providers.environmentVariable("CI").isPresent && hasStoredPostHogCredentials)
+
+tasks.withType<com.posthog.android.PostHogUploadProguardMappingsTask>().configureEach {
+    isEnabled = postHogUploadEnabled
 }

--- a/sample/androidApp/build.gradle.kts
+++ b/sample/androidApp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.posthogAndroid)
 }
 
 android {
@@ -17,6 +18,17 @@ android {
 
     buildFeatures {
         compose = true
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            signingConfig = signingConfigs.getByName("debug")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
     }
 
     compileOptions {

--- a/sample/androidApp/proguard-rules.pro
+++ b/sample/androidApp/proguard-rules.pro
@@ -1,0 +1,7 @@
+# Preserve the package prefix used by ErrorTrackingConfig.inAppIncludes after R8 obfuscation.
+-keeppackagenames com.posthog.kmp.sample.**
+
+# Keep app methods from being inlined into vendor classes while still allowing shrinking and obfuscation.
+-keep,allowshrinking,allowobfuscation class com.posthog.kmp.sample.** {
+    *;
+}

--- a/sample/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/sample/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 				49CE9E73EA13311C13F26D2E /* Sources */,
 				CCDF0391B7E30A322B718C78 /* Frameworks */,
 				E3142E7290D01099F16CA5D2 /* Resources */,
+				A91B4C2D3E4F5061728394A5 /* Upload PostHog dSYMs */,
 			);
 			buildRules = (
 			);
@@ -194,6 +195,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A91B4C2D3E4F5061728394A5 /* Upload PostHog dSYMs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(EXECUTABLE_NAME)",
+			);
+			name = "Upload PostHog dSYMs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/scripts/upload-posthog-dsyms.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		49CE9E73EA13311C13F26D2E /* Sources */ = {
@@ -288,6 +309,8 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGNING_ALLOWED = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../build/bin/iosSimulatorArm64/debugFramework",
@@ -318,6 +341,8 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGNING_ALLOWED = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../build/bin/iosSimulatorArm64/debugFramework",

--- a/sample/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/sample/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -204,7 +204,7 @@
 			files = (
 			);
 			inputPaths = (
-				"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(EXECUTABLE_NAME)",
+				"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)",
 			);
 			name = "Upload PostHog dSYMs";
 			outputPaths = (
@@ -342,6 +342,7 @@
 				CODE_SIGNING_ALLOWED = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/sample/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/sample/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -138,7 +138,6 @@
 				49CE9E73EA13311C13F26D2E /* Sources */,
 				CCDF0391B7E30A322B718C78 /* Frameworks */,
 				E3142E7290D01099F16CA5D2 /* Resources */,
-				A91B4C2D3E4F5061728394A5 /* Upload PostHog dSYMs */,
 			);
 			buildRules = (
 			);
@@ -195,26 +194,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		A91B4C2D3E4F5061728394A5 /* Upload PostHog dSYMs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)",
-			);
-			name = "Upload PostHog dSYMs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/scripts/upload-posthog-dsyms.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		49CE9E73EA13311C13F26D2E /* Sources */ = {

--- a/sample/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/sample/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -21,6 +21,24 @@
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Upload PostHog dSYMs"
+               scriptText = "&quot;${SRCROOT}/scripts/upload-posthog-dsyms.sh&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "883E9F4330DAEF760F828947"
+                     BuildableName = "iosApp.app"
+                     BlueprintName = "iosApp"
+                     ReferencedContainer = "container:iosApp.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"

--- a/sample/iosApp/iosApp/Info.plist
+++ b/sample/iosApp/iosApp/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/sample/iosApp/scripts/upload-posthog-dsyms.sh
+++ b/sample/iosApp/scripts/upload-posthog-dsyms.sh
@@ -22,6 +22,15 @@ if [[ -z "$(find "${DWARF_DSYM_FOLDER_PATH}" -name '*.dSYM' -type d -print -quit
     exit 1
 fi
 
+if [[ -n "${DWARF_DSYM_FILE_NAME:-}" ]]; then
+    MAIN_DSYM_PATH="${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}"
+    MAIN_DWARF_PATH="${MAIN_DSYM_PATH}/Contents/Resources/DWARF"
+    if [[ ! -d "${MAIN_DWARF_PATH}" || -z "$(find "${MAIN_DWARF_PATH}" -type f -size +0c -print -quit)" ]]; then
+        echo "error: Main dSYM is incomplete: ${MAIN_DSYM_PATH}"
+        exit 1
+    fi
+fi
+
 export PATH="/opt/homebrew/bin:/usr/local/bin:${HOME}/.posthog:${PATH}"
 POSTHOG_CLI_PATH="${POSTHOG_CLI_PATH:-$(command -v posthog-cli || true)}"
 if [[ -z "${POSTHOG_CLI_PATH}" || ! -x "${POSTHOG_CLI_PATH}" ]]; then

--- a/sample/iosApp/scripts/upload-posthog-dsyms.sh
+++ b/sample/iosApp/scripts/upload-posthog-dsyms.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${POSTHOG_UPLOAD_DSYMS:-0}" != "1" ]]; then
+    echo "info: Skipping PostHog dSYM upload. Set POSTHOG_UPLOAD_DSYMS=1 to enable it."
+    exit 0
+fi
+
+if [[ -n "${CONFIGURATION:-}" && "${CONFIGURATION}" != "Release" && "${POSTHOG_UPLOAD_DEBUG_SYMBOLS:-0}" != "1" ]]; then
+    echo "info: Skipping PostHog dSYM upload for ${CONFIGURATION}. Set POSTHOG_UPLOAD_DEBUG_SYMBOLS=1 to upload non-Release symbols."
+    exit 0
+fi
+
+if [[ -z "${DWARF_DSYM_FOLDER_PATH:-}" || ! -d "${DWARF_DSYM_FOLDER_PATH}" ]]; then
+    echo "error: DWARF_DSYM_FOLDER_PATH does not contain a dSYM directory: ${DWARF_DSYM_FOLDER_PATH:-<unset>}"
+    exit 1
+fi
+
+if [[ -z "$(find "${DWARF_DSYM_FOLDER_PATH}" -name '*.dSYM' -type d -print -quit)" ]]; then
+    echo "error: No dSYM bundles found in ${DWARF_DSYM_FOLDER_PATH}"
+    exit 1
+fi
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:${HOME}/.posthog:${PATH}"
+POSTHOG_CLI_PATH="${POSTHOG_CLI_PATH:-$(command -v posthog-cli || true)}"
+if [[ -z "${POSTHOG_CLI_PATH}" || ! -x "${POSTHOG_CLI_PATH}" ]]; then
+    echo "error: posthog-cli not found. Install it from https://posthog.com/docs/error-tracking/upload-source-maps/cli"
+    exit 1
+fi
+
+CLI_ARGS=(
+    dsym upload
+    --directory "${DWARF_DSYM_FOLDER_PATH}"
+)
+
+if [[ -n "${DWARF_DSYM_FILE_NAME:-}" ]]; then
+    CLI_ARGS+=(--main-dsym "${DWARF_DSYM_FILE_NAME}")
+fi
+if [[ -n "${PRODUCT_BUNDLE_IDENTIFIER:-}" ]]; then
+    CLI_ARGS+=(--release-name "${PRODUCT_BUNDLE_IDENTIFIER}")
+fi
+if [[ -n "${MARKETING_VERSION:-}" ]]; then
+    CLI_ARGS+=(--release-version "${MARKETING_VERSION}")
+fi
+if [[ -n "${CURRENT_PROJECT_VERSION:-}" ]]; then
+    CLI_ARGS+=(--build "${CURRENT_PROJECT_VERSION}")
+fi
+if [[ "${POSTHOG_INCLUDE_SOURCE:-0}" == "1" ]]; then
+    CLI_ARGS+=(--include-source)
+fi
+if [[ "${POSTHOG_SKIP_ON_CONFLICT:-0}" == "1" ]]; then
+    CLI_ARGS+=(--skip-on-conflict)
+fi
+
+"${POSTHOG_CLI_PATH}" "${CLI_ARGS[@]}"

--- a/sample/scripts/upload-posthog-sourcemaps.sh
+++ b/sample/scripts/upload-posthog-sourcemaps.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DIST_DIR="${POSTHOG_SOURCEMAP_DIR:-${ROOT_DIR}/sample/build/dist/js/productionExecutable}"
+RELEASE_NAME="${POSTHOG_RELEASE_NAME:-com.posthog.kmp.sample.web}"
+RELEASE_VERSION="${POSTHOG_RELEASE_VERSION:-$(git -C "${ROOT_DIR}" rev-parse HEAD)}"
+
+if [[ ! -f "${DIST_DIR}/sample.js" || ! -f "${DIST_DIR}/sample.js.map" ]]; then
+    echo "error: Production JavaScript bundle and source map not found in ${DIST_DIR}."
+    echo "error: Run ./gradlew :sample:jsBrowserDistribution first."
+    exit 1
+fi
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:${HOME}/.posthog:${PATH}"
+POSTHOG_CLI_PATH="${POSTHOG_CLI_PATH:-$(command -v posthog-cli || true)}"
+if [[ -z "${POSTHOG_CLI_PATH}" || ! -x "${POSTHOG_CLI_PATH}" ]]; then
+    echo "error: posthog-cli not found. Install it from https://posthog.com/docs/error-tracking/upload-source-maps/web"
+    exit 1
+fi
+
+RELEASE_ARGS=(
+    --release-name "${RELEASE_NAME}"
+    --release-version "${RELEASE_VERSION}"
+)
+if [[ -n "${POSTHOG_RELEASE_BUILD:-}" ]]; then
+    RELEASE_ARGS+=(--build "${POSTHOG_RELEASE_BUILD}")
+fi
+
+"${POSTHOG_CLI_PATH}" sourcemap inject \
+    --directory "${DIST_DIR}" \
+    "${RELEASE_ARGS[@]}"
+
+UPLOAD_ARGS=(
+    sourcemap upload
+    --directory "${DIST_DIR}"
+    "${RELEASE_ARGS[@]}"
+)
+if [[ "${POSTHOG_FORCE:-0}" == "1" ]]; then
+    UPLOAD_ARGS+=(--force)
+fi
+if [[ "${POSTHOG_SKIP_ON_CONFLICT:-0}" == "1" ]]; then
+    UPLOAD_ARGS+=(--skip-on-conflict)
+fi
+
+"${POSTHOG_CLI_PATH}" "${UPLOAD_ARGS[@]}"

--- a/sample/src/androidMain/kotlin/com/posthog/kmp/sample/Platform.android.kt
+++ b/sample/src/androidMain/kotlin/com/posthog/kmp/sample/Platform.android.kt
@@ -1,3 +1,7 @@
 package com.posthog.kmp.sample
 
 actual fun getPlatformName(): String = "Android"
+
+actual fun crashSampleApp(throwable: Throwable) {
+    throw throwable
+}

--- a/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
@@ -490,7 +490,7 @@ fun App(postHogContext: PostHogContext) {
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
                 ) { Text("Capture Sample Exception") }
                 Button(
-                    onClick = { error("Unhandled sample exception") },
+                    onClick = { crashSampleApp(IllegalStateException("Unhandled sample exception")) },
                     enabled = isInitialized,
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
@@ -549,3 +549,5 @@ fun App(postHogContext: PostHogContext) {
 }
 
 expect fun getPlatformName(): String
+
+expect fun crashSampleApp(throwable: Throwable)

--- a/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
@@ -96,7 +96,10 @@ fun App(postHogContext: PostHogContext) {
                                 config = PostHogConfig(
                                     apiKey = apiKey,
                                     debug = true,
-                                    errorTracking = ErrorTrackingConfig(autoCapture = true),
+                                    errorTracking = ErrorTrackingConfig(
+                                        autoCapture = true,
+                                        inAppIncludes = listOf("com.posthog.kmp.sample")
+                                    ),
                                     beforeSend = listOf(
                                         PostHogBeforeSend { event ->
                                             if (event.event == "before_send_drop_test") {

--- a/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
+++ b/sample/src/commonMain/kotlin/com/posthog/kmp/sample/App.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.posthog.kmp.ErrorTrackingConfig
 import com.posthog.kmp.PostHog
 import com.posthog.kmp.PostHogBeforeSend
 import com.posthog.kmp.PostHogConfig
@@ -95,6 +96,7 @@ fun App(postHogContext: PostHogContext) {
                                 config = PostHogConfig(
                                     apiKey = apiKey,
                                     debug = true,
+                                    errorTracking = ErrorTrackingConfig(autoCapture = true),
                                     beforeSend = listOf(
                                         PostHogBeforeSend { event ->
                                             if (event.event == "before_send_drop_test") {
@@ -487,6 +489,12 @@ fun App(postHogContext: PostHogContext) {
                     enabled = isInitialized, modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
                 ) { Text("Capture Sample Exception") }
+                Button(
+                    onClick = { error("Unhandled sample exception") },
+                    enabled = isInitialized,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Crash Sample App") }
 
                 HorizontalDivider()
 

--- a/sample/src/iosMain/kotlin/com/posthog/kmp/sample/Platform.ios.kt
+++ b/sample/src/iosMain/kotlin/com/posthog/kmp/sample/Platform.ios.kt
@@ -1,5 +1,13 @@
+@file:OptIn(ExperimentalNativeApi::class)
+
 package com.posthog.kmp.sample
 
 import platform.UIKit.UIDevice
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.processUnhandledException
 
 actual fun getPlatformName(): String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+
+actual fun crashSampleApp(throwable: Throwable) {
+    processUnhandledException(throwable)
+}

--- a/sample/src/jsMain/kotlin/com/posthog/kmp/sample/Platform.js.kt
+++ b/sample/src/jsMain/kotlin/com/posthog/kmp/sample/Platform.js.kt
@@ -1,3 +1,7 @@
 package com.posthog.kmp.sample
 
 actual fun getPlatformName(): String = "Web Browser (JS)"
+
+actual fun crashSampleApp(throwable: Throwable) {
+    throw throwable
+}

--- a/sample/src/jvmMain/kotlin/com/posthog/kmp/sample/Platform.jvm.kt
+++ b/sample/src/jvmMain/kotlin/com/posthog/kmp/sample/Platform.jvm.kt
@@ -1,3 +1,7 @@
 package com.posthog.kmp.sample
 
 actual fun getPlatformName(): String = System.getProperty("os.name") ?: "JVM"
+
+actual fun crashSampleApp(throwable: Throwable) {
+    throw throwable
+}

--- a/sample/src/wasmJsMain/kotlin/com/posthog/kmp/sample/Platform.wasmJs.kt
+++ b/sample/src/wasmJsMain/kotlin/com/posthog/kmp/sample/Platform.wasmJs.kt
@@ -1,3 +1,7 @@
 package com.posthog.kmp.sample
 
 actual fun getPlatformName(): String = "Web Browser (Wasm)"
+
+actual fun crashSampleApp(throwable: Throwable) {
+    throw throwable
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

The KMP wrapper supports manually capturing exceptions, but it does not expose the native SDK settings for automatically capturing unhandled exceptions. This means KMP applications cannot enable native crash capture through shared configuration.

The iOS sample also needs a repeatable way to generate and upload dSYMs so Kotlin and Swift frames can be symbolicated during an end-to-end crash test.

Closes #55.

## :green_heart: How did you test it?

- `./gradlew detekt :posthog-kmp:jvmTest :posthog-kmp:testAndroid :posthog-kmp:jsBrowserTest :posthog-kmp:wasmJsBrowserTest :posthog-kmp:iosSimulatorArm64Test :sample:androidApp:assembleDebug`
- Built the iOS simulator app with `xcodebuildmcp` and verified the dSYM upload phase is skipped cleanly unless enabled.
- Uploaded a Debug simulator dSYM with `posthog-cli 0.11.2`. PostHog accepted both UUIDs from the app dSYM.
- Crashed the sample on an iPhone 17 simulator, relaunched it, and verified the pending `$exception` batch was sent successfully.
- Queried the resulting PostHog issue and confirmed the uploaded symbol set was used to resolve Swift and Kotlin/Compose frames.
- Crashed the Android sample on an API 36.1 emulator, relaunched it, and verified the persisted fatal `$exception` batch received an `Ok` response from US PostHog.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using GPT-5.6. The shared API uses an `ErrorTrackingConfig` object instead of a flat boolean so it can expose automatic exception capture, frame classification, and ignored exception types. The wrapper maps the supported settings to Android, JVM, iOS, JS, and Wasm.

The sample enables exception autocapture and includes an explicit crash button. Its iOS target generates Debug and Release dSYMs and has an opt-in final build phase that calls a checked-in `posthog-cli` upload script. Uploads remain disabled unless `POSTHOG_UPLOAD_DSYMS=1` is set, so normal local and CI builds do not require PostHog credentials.
