### PR TITLE
build: replace deprecated Gradle DSL APIs

### DIFF
--- a/.changeset/red-donuts-follow.md
+++ b/.changeset/red-donuts-follow.md
@@ -1,0 +1,5 @@
+---
+"posthog-kmp": patch
+---
+
+Update Gradle build scripts to use supported APIs.

--- a/.changeset/red-donuts-follow.md
+++ b/.changeset/red-donuts-follow.md
@@ -1,5 +1,0 @@
----
-"posthog-kmp": patch
----
-
-Update Gradle build scripts to use supported APIs.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "2.4.10"
 agp = "9.3.1"
 android-compileSdk = "36"
 compose-multiplatform = "1.11.1"
+compose-material3 = "1.9.0"
 androidx-activity-compose = "1.13.0"
 posthog-android = "3.58.0"
 # Pure-JVM core that posthog-android is built on (versioned independently of posthog-android)
@@ -21,6 +22,12 @@ kotlin-test = "2.4.10"
 [libraries]
 # AndroidX
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
+# Compose
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
+compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-material3" }
+compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-multiplatform" }
 # Kotlin
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 

--- a/posthog-kmp/build.gradle.kts
+++ b/posthog-kmp/build.gradle.kts
@@ -2,6 +2,7 @@
 
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 import io.github.frankois944.spmForKmp.swiftPackageConfig
 import io.github.frankois944.spmForKmp.utils.ExperimentalSpmForKmpFeature
 import java.util.Properties
@@ -24,7 +25,7 @@ version = "$versionMajor.$versionMinor.$versionPatch"
 // Generate a common Kotlin source exposing the SDK version (single source of truth:
 // version.properties) so platform implementations can report it to PostHog.
 val generatedVersionDir = layout.buildDirectory.dir("generated/posthogVersion/kotlin")
-val generatePostHogVersion by tasks.registering {
+val generatePostHogVersion = tasks.register("generatePostHogVersion") {
     val versionValue = version.toString()
     val outputDir = generatedVersionDir
     inputs.property("version", versionValue)
@@ -50,7 +51,7 @@ val generatePostHogVersion by tasks.registering {
 kotlin {
     explicitApi()
 
-    androidLibrary {
+    android {
         namespace = "com.posthog.kmp"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = 21
@@ -81,7 +82,7 @@ kotlin {
         }
     }
 
-    js(IR) {
+    js {
         browser {
             webpackTask {
                 mainOutputFileName = "posthog-kmp.js"
@@ -104,46 +105,46 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             kotlin.srcDir(generatedVersionDir)
         }
 
-        val commonTest by getting {
+        val commonTest = getByName("commonTest") {
             dependencies {
                 implementation(libs.kotlin.test)
             }
         }
 
         // shared delegation to the core PostHogInterface for the two JVM-backed targets
-        val jvmCommonMain by creating {
+        val jvmCommonMain = create("jvmCommonMain") {
             dependsOn(commonMain)
             dependencies {
                 implementation(libs.posthog.core)
             }
         }
 
-        val androidMain by getting {
+        getByName("androidMain") {
             dependsOn(jvmCommonMain)
             dependencies {
                 implementation(libs.posthog.android)
             }
         }
 
-        val iosMain by creating {
+        val iosMain = create("iosMain") {
             dependsOn(commonMain)
         }
-        val iosTest by creating {
+        val iosTest = create("iosTest") {
             dependsOn(commonTest)
         }
 
-        val iosX64Main by getting { dependsOn(iosMain) }
+        getByName("iosX64Main") { dependsOn(iosMain) }
         getByName("iosX64Test") { dependsOn(iosTest) }
-        val iosArm64Main by getting { dependsOn(iosMain) }
+        getByName("iosArm64Main") { dependsOn(iosMain) }
         getByName("iosArm64Test") { dependsOn(iosTest) }
-        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+        getByName("iosSimulatorArm64Main") { dependsOn(iosMain) }
         getByName("iosSimulatorArm64Test") { dependsOn(iosTest) }
 
-        val jsMain by getting {
+        getByName("jsMain") {
             dependencies {
                 implementation(npm("posthog-js", libs.versions.posthog.js.get()))
             }
@@ -182,7 +183,7 @@ mavenPublishing {
 
     configure(KotlinMultiplatform(
         javadocJar = JavadocJar.Empty(),
-        sourcesJar = true
+        sourcesJar = SourcesJar.Sources()
     ))
 
     pom {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.posthog.kmp.sample.shared"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = 24
@@ -28,7 +28,7 @@ kotlin {
         }
     }
 
-    js(IR) {
+    js {
         browser()
         binaries.executable()
     }
@@ -42,25 +42,25 @@ kotlin {
     jvm()
 
     sourceSets {
-        val commonMain by getting {
+        val commonMain = getByName("commonMain") {
             dependencies {
                 api(project(":posthog-kmp"))
-                implementation(compose.runtime)
-                implementation(compose.foundation)
-                implementation(compose.material3)
-                implementation(compose.ui)
-                implementation(compose.components.resources)
+                implementation(libs.compose.runtime)
+                implementation(libs.compose.foundation)
+                implementation(libs.compose.material3)
+                implementation(libs.compose.ui)
+                implementation(libs.compose.components.resources)
             }
         }
 
-        val iosMain by creating {
+        val iosMain = create("iosMain") {
             dependsOn(commonMain)
         }
 
-        val iosArm64Main by getting { dependsOn(iosMain) }
-        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+        getByName("iosArm64Main") { dependsOn(iosMain) }
+        getByName("iosSimulatorArm64Main") { dependsOn(iosMain) }
 
-        val jsMain by getting {
+        getByName("jsMain") {
             dependsOn(commonMain)
         }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Gradle 9.6 and Kotlin 2.4 report deprecation warnings while configuring the SDK and sample projects. Several of these APIs are scheduled for removal in later Gradle or Kotlin releases.

This updates task registration, Kotlin source set access, Android and JavaScript target configuration, Compose dependencies, and Maven source JAR configuration to use their supported replacements.

## :green_heart: How did you test it?

- Ran `./gradlew build allTests publishToMavenLocal --warning-mode all --no-configuration-cache`.
- Compiled the sample for Android, JVM, JavaScript, and iOS.
- Ran Gradle configuration again and confirmed the targeted build script deprecation warnings no longer appear.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi updated the build scripts in a dedicated worktree and ran the project build and platform compilation checks. No release change intent is included because the change only updates build configuration. Pi's isolated autoreview reported no actionable findings.
