### PR TITLE
fix: remove build paths from published iOS KLIBs

### DIFF
--- a/.changeset/few-numbers-scream.md
+++ b/.changeset/few-numbers-scream.md
@@ -1,0 +1,5 @@
+---
+"posthog-kmp": patch
+---
+
+Fix iOS linking when consumers use a different Xcode installation path.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Build iOS
         run: ./gradlew :posthog-kmp:compileKotlinIosArm64 --no-daemon
 
+      - name: Test published iOS library
+        run: ./scripts/test-ios-publication.sh
+
       - name: Build macOS desktop sample release
         run: ./gradlew :sample:packageReleaseDmg --no-daemon
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,6 @@ jobs:
       - name: Build iOS
         run: ./gradlew :posthog-kmp:compileKotlinIosArm64 --no-daemon
 
-      - name: Test published iOS library
-        run: ./scripts/test-ios-publication.sh
-
       - name: Build macOS desktop sample release
         run: ./gradlew :sample:packageReleaseDmg --no-daemon
 
@@ -194,3 +191,31 @@ jobs:
 
       - name: Assemble publications (no upload, signing skipped without key)
         run: ./gradlew publishToMavenLocal --no-daemon
+
+  release-dry-run-ios:
+    name: Release Dry Run (iOS)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
+
+      - name: Cache Kotlin Native
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-
+
+      - name: Test published iOS library
+        run: ./scripts/test-ios-publication.sh

--- a/posthog-kmp/build.gradle.kts
+++ b/posthog-kmp/build.gradle.kts
@@ -7,6 +7,13 @@ import io.github.frankois944.spmForKmp.swiftPackageConfig
 import io.github.frankois944.spmForKmp.utils.ExperimentalSpmForKmpFeature
 import java.util.Properties
 
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidKmpLibrary)
+    alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.spmforkmp)
+}
+
 val swiftCompatibilitySymbols = listOf(
     "__swift_FORCE_LOAD_\$_swiftCompatibility50",
     "__swift_FORCE_LOAD_\$_swiftCompatibility51",
@@ -16,13 +23,6 @@ val swiftCompatibilitySymbols = listOf(
     "__swift_FORCE_LOAD_\$_swiftCompatibilityPacks"
 )
 val portableSwiftLinkerOpts = swiftCompatibilitySymbols.joinToString(" ") { "-U $it" }
-
-plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidKmpLibrary)
-    alias(libs.plugins.mavenPublish)
-    alias(libs.plugins.spmforkmp)
-}
 
 val versionProperties = Properties().apply {
     rootProject.file("version.properties").inputStream().use { load(it) }

--- a/posthog-kmp/build.gradle.kts
+++ b/posthog-kmp/build.gradle.kts
@@ -5,6 +5,7 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SourcesJar
 import io.github.frankois944.spmForKmp.swiftPackageConfig
 import io.github.frankois944.spmForKmp.utils.ExperimentalSpmForKmpFeature
+import java.io.File
 import java.util.Properties
 
 plugins {
@@ -14,15 +15,22 @@ plugins {
     alias(libs.plugins.spmforkmp)
 }
 
-val swiftCompatibilitySymbols = listOf(
-    "__swift_FORCE_LOAD_\$_swiftCompatibility50",
-    "__swift_FORCE_LOAD_\$_swiftCompatibility51",
-    "__swift_FORCE_LOAD_\$_swiftCompatibility56",
-    "__swift_FORCE_LOAD_\$_swiftCompatibilityConcurrency",
-    "__swift_FORCE_LOAD_\$_swiftCompatibilityDynamicReplacements",
-    "__swift_FORCE_LOAD_\$_swiftCompatibilityPacks"
+val swiftCompatibilityLibraries = listOf(
+    "swiftCompatibility50",
+    "swiftCompatibility51",
+    "swiftCompatibility56",
+    "swiftCompatibilityConcurrency",
+    "swiftCompatibilityDynamicReplacements",
+    "swiftCompatibilityPacks"
 )
-val portableSwiftLinkerOpts = swiftCompatibilitySymbols.joinToString(" ") { "-U $it" }
+val portableSwiftLinkerOpts = swiftCompatibilityLibraries.joinToString(" ") {
+    "-U __swift_FORCE_LOAD_\$_$it"
+}
+val swiftToolchainDirectory = providers.exec {
+    commandLine("/usr/bin/xcrun", "--toolchain", "XcodeDefault", "--find", "swiftc")
+}.standardOutput.asText.map { output ->
+    File(output.trim()).parentFile.parentFile
+}
 
 val versionProperties = Properties().apply {
     rootProject.file("version.properties").inputStream().use { load(it) }
@@ -243,18 +251,58 @@ tasks.matching { it.name.endsWith("sourcesJar", ignoreCase = true) }.configureEa
 }
 
 // spmForKmp needs producer-local paths while generating the cinterop, but those paths are not
-// valid after publication. The static Swift archive is already embedded in the KLIB, so keep only
-// portable options for its Swift compatibility force-load markers.
+// valid after publication. Embed the Swift back-deployment libraries in the KLIB and keep only
+// portable linker options for their force-load markers.
 tasks.matching { it.name.startsWith("cinteropPostHogBridge") }.configureEach {
+    val swiftPlatform = when {
+        name.endsWith("IosArm64") -> "iphoneos"
+        name.endsWith("IosSimulatorArm64") || name.endsWith("IosX64") -> "iphonesimulator"
+        else -> error("Unsupported PostHogBridge cinterop target: $name")
+    }
+    val compatibilityArchives = swiftCompatibilityLibraries.map { library ->
+        swiftToolchainDirectory.map { toolchainDirectory ->
+            toolchainDirectory.resolve("lib/swift/$swiftPlatform/lib$library.a")
+        }
+    }
+
     inputs.property("portableSwiftLinkerOpts", portableSwiftLinkerOpts)
+    inputs.property("swiftCompatibilityArchiveNames", swiftCompatibilityLibraries.joinToString(" ") { "lib$it.a" })
+    inputs.files(compatibilityArchives)
+        .withPropertyName("swiftCompatibilityArchives")
+        .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.NONE)
+
     doLast {
         val linkerOpts = inputs.properties.getValue("portableSwiftLinkerOpts") as String
-        outputs.files.asFileTree.matching { include("**/default/manifest") }.forEach { manifest ->
-            val sanitizedManifest = manifest.readLines().mapNotNull { line ->
+        val archiveNames = (inputs.properties.getValue("swiftCompatibilityArchiveNames") as String).split(' ')
+        val archivesByName = inputs.files.files.filter { it.name in archiveNames }.associateBy { it.name }
+        check(archivesByName.keys == archiveNames.toSet()) {
+            "Could not resolve every Swift compatibility archive for $name"
+        }
+        val archives = archiveNames.map(archivesByName::getValue)
+        val manifests = outputs.files.asFileTree.matching { include("**/default/manifest") }.files
+        check(manifests.isNotEmpty()) { "No cinterop manifest found in outputs of $name" }
+
+        manifests.forEach { manifest ->
+            val lines = manifest.readLines()
+            listOf("compilerOpts=", "libraryPaths=", "linkerOpts=", "staticLibraries=").forEach { key ->
+                check(lines.count { it.startsWith(key) } == 1) {
+                    "Expected exactly one $key entry in ${manifest.absolutePath}"
+                }
+            }
+
+            val nativeTarget = lines.single { it.startsWith("native_targets=") }.substringAfter('=')
+            val includedLibraries = manifest.parentFile.resolve("targets/$nativeTarget/included")
+            archives.forEach { archive ->
+                archive.copyTo(includedLibraries.resolve(archive.name), overwrite = true)
+            }
+
+            val archiveNames = archives.joinToString(" ") { it.name }
+            val sanitizedManifest = lines.mapNotNull { line ->
                 when {
                     line.startsWith("compilerOpts=") -> null
                     line.startsWith("libraryPaths=") -> null
                     line.startsWith("linkerOpts=") -> "linkerOpts=$linkerOpts"
+                    line.startsWith("staticLibraries=") -> "$line $archiveNames"
                     else -> line
                 }
             }.joinToString("\n", postfix = "\n")

--- a/posthog-kmp/build.gradle.kts
+++ b/posthog-kmp/build.gradle.kts
@@ -7,6 +7,16 @@ import io.github.frankois944.spmForKmp.swiftPackageConfig
 import io.github.frankois944.spmForKmp.utils.ExperimentalSpmForKmpFeature
 import java.util.Properties
 
+val swiftCompatibilitySymbols = listOf(
+    "__swift_FORCE_LOAD_\$_swiftCompatibility50",
+    "__swift_FORCE_LOAD_\$_swiftCompatibility51",
+    "__swift_FORCE_LOAD_\$_swiftCompatibility56",
+    "__swift_FORCE_LOAD_\$_swiftCompatibilityConcurrency",
+    "__swift_FORCE_LOAD_\$_swiftCompatibilityDynamicReplacements",
+    "__swift_FORCE_LOAD_\$_swiftCompatibilityPacks"
+)
+val portableSwiftLinkerOpts = swiftCompatibilitySymbols.joinToString(" ") { "-U $it" }
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidKmpLibrary)
@@ -230,4 +240,25 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>>().con
 }
 tasks.matching { it.name.endsWith("sourcesJar", ignoreCase = true) }.configureEach {
     dependsOn(generatePostHogVersion)
+}
+
+// spmForKmp needs producer-local paths while generating the cinterop, but those paths are not
+// valid after publication. The static Swift archive is already embedded in the KLIB, so keep only
+// portable options for its Swift compatibility force-load markers.
+tasks.matching { it.name.startsWith("cinteropPostHogBridge") }.configureEach {
+    inputs.property("portableSwiftLinkerOpts", portableSwiftLinkerOpts)
+    doLast {
+        val linkerOpts = inputs.properties.getValue("portableSwiftLinkerOpts") as String
+        outputs.files.asFileTree.matching { include("**/default/manifest") }.forEach { manifest ->
+            val sanitizedManifest = manifest.readLines().mapNotNull { line ->
+                when {
+                    line.startsWith("compilerOpts=") -> null
+                    line.startsWith("libraryPaths=") -> null
+                    line.startsWith("linkerOpts=") -> "linkerOpts=$linkerOpts"
+                    else -> line
+                }
+            }.joinToString("\n", postfix = "\n")
+            manifest.writeText(sanitizedManifest)
+        }
+    }
 }

--- a/scripts/test-ios-publication.sh
+++ b/scripts/test-ios-publication.sh
@@ -24,6 +24,23 @@ if grep -Eq '(^|[=" ])/' <<<"$manifest" || grep -Eq '^(compilerOpts|libraryPaths
     exit 1
 fi
 
+compatibility_libraries=(
+    swiftCompatibility50
+    swiftCompatibility51
+    swiftCompatibility56
+    swiftCompatibilityConcurrency
+    swiftCompatibilityDynamicReplacements
+    swiftCompatibilityPacks
+)
+for library in "${compatibility_libraries[@]}"; do
+    archive="lib$library.a"
+    if ! grep -Eq "^staticLibraries=.*(^| )$archive( |$)" <<<"$manifest" ||
+        ! unzip -Z1 "$cinterop_klib" | grep -Fqx "default/targets/ios_simulator_arm64/included/$archive"; then
+        echo "Published iOS KLIB does not embed $archive" >&2
+        exit 1
+    fi
+done
+
 mkdir -p "$consumer/src/commonTest/kotlin"
 cat > "$consumer/settings.gradle.kts" <<EOF
 pluginManagement {
@@ -81,3 +98,10 @@ class PostHogLinkTest {
 EOF
 
 "$root_dir/gradlew" -p "$consumer" iosSimulatorArm64Test --no-daemon --console=plain
+
+test_binary="$consumer/build/bin/iosSimulatorArm64/debugTest/test.kexe"
+if xcrun nm -m "$test_binary" | grep -Eq '\(undefined\).*swiftCompatibility'; then
+    echo "Published iOS library leaves Swift compatibility symbols unresolved:" >&2
+    xcrun nm -m "$test_binary" | grep 'swiftCompatibility' >&2
+    exit 1
+fi

--- a/scripts/test-ios-publication.sh
+++ b/scripts/test-ios-publication.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir=$(cd "$(dirname "$0")/.." && pwd)
+version="$(sed -n 's/^VERSION_MAJOR=//p' "$root_dir/version.properties").$(sed -n 's/^VERSION_MINOR=//p' "$root_dir/version.properties").$(sed -n 's/^VERSION_PATCH=//p' "$root_dir/version.properties")"
+kotlin_version=$(sed -n 's/^kotlin = "\([^"]*\)"/\1/p' "$root_dir/gradle/libs.versions.toml")
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+local_repo="$tmp_dir/repository"
+consumer="$tmp_dir/consumer"
+
+"$root_dir/gradlew" -p "$root_dir" \
+    :posthog-kmp:publishKotlinMultiplatformPublicationToMavenLocal \
+    :posthog-kmp:publishIosSimulatorArm64PublicationToMavenLocal \
+    -Dmaven.repo.local="$local_repo" \
+    --no-daemon \
+    --no-configuration-cache
+
+cinterop_klib="$local_repo/com/posthog/posthog-kmp-iossimulatorarm64/$version/posthog-kmp-iossimulatorarm64-$version-cinterop-PostHogBridge.klib"
+manifest=$(unzip -p "$cinterop_klib" default/manifest)
+if grep -Eq '(^|[=" ])/' <<<"$manifest" || grep -Eq '^(compilerOpts|libraryPaths)=' <<<"$manifest"; then
+    echo "Published iOS KLIB contains producer-local paths:" >&2
+    echo "$manifest" >&2
+    exit 1
+fi
+
+mkdir -p "$consumer/src/commonTest/kotlin"
+cat > "$consumer/settings.gradle.kts" <<EOF
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        maven { url = uri("$local_repo") }
+        mavenCentral()
+    }
+}
+
+rootProject.name = "posthog-kmp-ios-link-test"
+EOF
+
+cat > "$consumer/build.gradle.kts" <<EOF
+plugins {
+    kotlin("multiplatform") version "$kotlin_version"
+}
+
+kotlin {
+    iosSimulatorArm64()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation("com.posthog:posthog-kmp:$version")
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
+}
+EOF
+
+cat > "$consumer/src/commonTest/kotlin/PostHogLinkTest.kt" <<'EOF'
+import com.posthog.kmp.PostHog
+import com.posthog.kmp.PostHogConfig
+import com.posthog.kmp.PostHogContext
+import kotlin.test.Test
+
+class PostHogLinkTest {
+    @Test
+    fun linksPostHogIosBridge() {
+        PostHog.setup(
+            config = PostHogConfig(apiKey = "test", preloadFeatureFlags = false),
+            context = PostHogContext(),
+        )
+        PostHog.close()
+    }
+}
+EOF
+
+"$root_dir/gradlew" -p "$consumer" iosSimulatorArm64Test --no-daemon --console=plain


### PR DESCRIPTION
## :bulb: Motivation and Context

The iOS cinterop KLIB published in version 0.4.0 contains paths to the release runner's workspace and Xcode installation. Kotlin/Native consumers with Xcode installed at a different path cannot link iOS test executables because the linker cannot find the Swift compatibility libraries.

Closes #60.

## :green_heart: How did you test it?

- Ran `./scripts/test-ios-publication.sh`. It published to an isolated Maven repository, verified that the cinterop manifest has no absolute paths, and ran the issue's iOS simulator consumer test.
- Ran `./gradlew :posthog-kmp:iosSimulatorArm64Test --no-daemon`.
- Ran `./gradlew :posthog-kmp:publishToMavenLocal --no-daemon --no-configuration-cache` and inspected all three iOS cinterop manifests.
- Ran `./gradlew detekt --no-daemon --console=plain`.
- Ran ShellCheck and actionlint on the new script and CI workflow.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The build still uses local paths while spmForKmp creates the cinterop, then removes those paths before packaging the KLIB. The published manifest keeps only linker options for the specific Swift compatibility force-load markers. A dedicated macOS release dry run checks the manifest and runs the iOS simulator test from the published artifacts.
