### PR TITLE
fix: drop events when beforeSend callbacks throw

### DIFF
--- a/.changeset/big-ends-share.md
+++ b/.changeset/big-ends-share.md
@@ -1,0 +1,5 @@
+---
+"posthog-kmp": patch
+---
+
+Drop events when a before-send callback throws.

--- a/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogBeforeSend.kt
+++ b/posthog-kmp/src/commonMain/kotlin/com/posthog/kmp/PostHogBeforeSend.kt
@@ -16,8 +16,8 @@ public data class PostHogEvent(
  * Synchronous hook invoked before an event is queued.
  *
  * Callbacks run in configuration order. Return the same or a modified [PostHogEvent] to continue,
- * or `null` to drop the event and skip the remaining callbacks. If a callback throws, its changes
- * are ignored and the remaining callbacks continue with the last valid event.
+ * or `null` to drop the event and skip the remaining callbacks. If a callback throws, the event is
+ * dropped and the remaining callbacks are skipped.
  */
 public fun interface PostHogBeforeSend {
     public fun run(event: PostHogEvent): PostHogEvent?
@@ -33,7 +33,7 @@ internal fun PostHogConfig.runBeforeSend(
             callback.run(current) ?: return null
         } catch (error: Throwable) {
             onError(error)
-            current
+            return null
         }
     }
     return current

--- a/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
+++ b/posthog-kmp/src/commonTest/kotlin/com/posthog/kmp/PostHogConfigTest.kt
@@ -85,13 +85,18 @@ class PostHogConfigTest {
     }
 
     @Test
-    fun beforeSendContinuesAfterCallbackException() {
+    fun beforeSendDropsTransformedEventAndStopsAfterCallbackException() {
         var errorCount = 0
+        var sentinelCalled = false
         val config = PostHogConfig(
             apiKey = "phc_test",
             beforeSend = listOf(
+                PostHogBeforeSend { it.copy(event = "transformed") },
                 PostHogBeforeSend { throw IllegalStateException("failed") },
-                PostHogBeforeSend { it.copy(event = "continued") }
+                PostHogBeforeSend {
+                    sentinelCalled = true
+                    it
+                }
             )
         )
 
@@ -99,7 +104,8 @@ class PostHogConfigTest {
             errorCount++
         }
 
-        assertEquals("continued", result?.event)
+        assertNull(result)
+        assertEquals(false, sentinelCalled)
         assertEquals(1, errorCount)
     }
 

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -67,7 +67,7 @@ private fun processBeforeSend(config: PostHogConfig, event: Map<Any?, *>?): Map<
     event ?: return null
     val postHogEvent = event.toPostHogEvent() ?: return null
     val processed = config.runBeforeSend(postHogEvent) {
-        NSLog("[PostHog] Before-send callback failed; event was dropped.")
+        if (config.debug) NSLog("[PostHog] Before-send callback failed; event was dropped.")
     } ?: return null
     return mapOf(
         "event" to processed.event,

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -67,7 +67,7 @@ private fun processBeforeSend(config: PostHogConfig, event: Map<Any?, *>?): Map<
     event ?: return null
     val postHogEvent = event.toPostHogEvent() ?: return null
     val processed = config.runBeforeSend(postHogEvent) {
-        if (config.debug) NSLog("[PostHog] Before-send callback failed and was ignored.")
+        NSLog("[PostHog] Before-send callback failed; event was dropped.")
     } ?: return null
     return mapOf(
         "event" to processed.event,

--- a/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
+++ b/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
@@ -324,7 +324,7 @@ private fun processBeforeSend(config: PostHogConfig, captureResult: dynamic): dy
     return try {
         val event = dynamicToPostHogEvent(captureResult) ?: return null
         val processed = config.runBeforeSend(event) {
-            console.error("[PostHog] Before-send callback failed; event was dropped.")
+            if (config.debug) console.error("[PostHog] Before-send callback failed; event was dropped.")
         } ?: return null
 
         captureResult.event = processed.event

--- a/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
+++ b/posthog-kmp/src/jsMain/kotlin/com/posthog/kmp/PostHog.js.kt
@@ -324,7 +324,7 @@ private fun processBeforeSend(config: PostHogConfig, captureResult: dynamic): dy
     return try {
         val event = dynamicToPostHogEvent(captureResult) ?: return null
         val processed = config.runBeforeSend(event) {
-            if (config.debug) console.error("[PostHog] Before-send callback failed and was ignored.")
+            console.error("[PostHog] Before-send callback failed; event was dropped.")
         } ?: return null
 
         captureResult.event = processed.event

--- a/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
+++ b/posthog-kmp/src/jsTest/kotlin/com/posthog/kmp/PostHogJsTest.kt
@@ -361,6 +361,7 @@ class PostHogJsTest {
 
     @Test
     fun testBeforeSendContainsCallbackAndConversionExceptions() {
+        var sentinelCalled = false
         fakeJs.init = { _: String, options: dynamic ->
             calledMethods.add("init" to arrayOf<dynamic>(options))
         }
@@ -368,8 +369,12 @@ class PostHogJsTest {
             PostHogConfig(
                 apiKey = "key",
                 beforeSend = listOf(
+                    PostHogBeforeSend { it.copy(event = "transformed") },
                     PostHogBeforeSend { throw IllegalStateException("failed") },
-                    PostHogBeforeSend { it.copy(event = "continued") }
+                    PostHogBeforeSend {
+                        sentinelCalled = true
+                        it
+                    }
                 )
             ),
             PostHogContext()
@@ -378,7 +383,8 @@ class PostHogJsTest {
 
         val result = callback(js("({ event: 'checkout', properties: { distinct_id: 'user-1' } })"))
 
-        assertEquals("continued", result.event as String)
+        assertNull(result)
+        assertEquals(false, sentinelCalled)
         assertNull(callback(createThrowingCaptureResult()))
     }
 

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -26,12 +26,7 @@ internal fun com.posthog.PostHogConfig.configureBeforeSend(config: PostHogConfig
                 properties = event.properties.orEmpty()
             ),
             onError = {
-                val message = "Before-send callback failed; event was dropped."
-                if (logger.isEnabled()) {
-                    logger.log(message)
-                } else {
-                    System.err.println("[PostHog] $message")
-                }
+                logger.log("Before-send callback failed; event was dropped.")
             }
         )?.let { processed ->
             event.copy(

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -26,7 +26,7 @@ internal fun com.posthog.PostHogConfig.configureBeforeSend(config: PostHogConfig
                 properties = event.properties.orEmpty()
             ),
             onError = {
-                logger.log("Before-send callback failed; event was dropped.")
+                if (config.debug) logger.log("Before-send callback failed; event was dropped.")
             }
         )?.let { processed ->
             event.copy(

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -26,7 +26,7 @@ internal fun com.posthog.PostHogConfig.configureBeforeSend(config: PostHogConfig
                 properties = event.properties.orEmpty()
             ),
             onError = {
-                if (config.debug) logger.log("Before-send callback failed and was ignored.")
+                logger.log("Before-send callback failed; event was dropped.")
             }
         )?.let { processed ->
             event.copy(

--- a/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
+++ b/posthog-kmp/src/jvmCommonMain/kotlin/com/posthog/kmp/PostHog.jvmCommon.kt
@@ -26,7 +26,12 @@ internal fun com.posthog.PostHogConfig.configureBeforeSend(config: PostHogConfig
                 properties = event.properties.orEmpty()
             ),
             onError = {
-                logger.log("Before-send callback failed; event was dropped.")
+                val message = "Before-send callback failed; event was dropped."
+                if (logger.isEnabled()) {
+                    logger.log(message)
+                } else {
+                    System.err.println("[PostHog] $message")
+                }
             }
         )?.let { processed ->
             event.copy(

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -1,11 +1,14 @@
 package com.posthog.kmp
 
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import java.time.OffsetDateTime
 import java.util.Date
 import java.util.TimeZone
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.BeforeTest
 
@@ -281,5 +284,34 @@ class PostHogJvmTest {
         assertEquals(false, result?.properties?.containsKey("email"))
         assertEquals(timestamp, result?.timestamp)
         assertEquals(uuid, result?.uuid)
+    }
+
+    @Test
+    fun testBeforeSendFailureLogsWhenDebugIsDisabled() {
+        val wrapperConfig = PostHogConfig(
+            apiKey = "key",
+            beforeSend = listOf(PostHogBeforeSend { throw IllegalStateException("failed") })
+        )
+        val nativeConfig = com.posthog.PostHogConfig(apiKey = "key")
+        nativeConfig.debug = false
+        nativeConfig.configureBeforeSend(wrapperConfig)
+        val output = ByteArrayOutputStream()
+        val originalError = System.err
+
+        val result = try {
+            System.setErr(PrintStream(output))
+            nativeConfig.beforeSendList.single().run(
+                com.posthog.PostHogEvent(
+                    event = "checkout",
+                    distinctId = "user-1",
+                    properties = mutableMapOf()
+                )
+            )
+        } finally {
+            System.setErr(originalError)
+        }
+
+        assertNull(result)
+        assertTrue(output.toString().contains("[PostHog] Before-send callback failed; event was dropped."))
     }
 }

--- a/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
+++ b/posthog-kmp/src/jvmTest/kotlin/com/posthog/kmp/PostHogJvmTest.kt
@@ -1,14 +1,11 @@
 package com.posthog.kmp
 
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
 import java.time.OffsetDateTime
 import java.util.Date
 import java.util.TimeZone
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.BeforeTest
 
@@ -284,34 +281,5 @@ class PostHogJvmTest {
         assertEquals(false, result?.properties?.containsKey("email"))
         assertEquals(timestamp, result?.timestamp)
         assertEquals(uuid, result?.uuid)
-    }
-
-    @Test
-    fun testBeforeSendFailureLogsWhenDebugIsDisabled() {
-        val wrapperConfig = PostHogConfig(
-            apiKey = "key",
-            beforeSend = listOf(PostHogBeforeSend { throw IllegalStateException("failed") })
-        )
-        val nativeConfig = com.posthog.PostHogConfig(apiKey = "key")
-        nativeConfig.debug = false
-        nativeConfig.configureBeforeSend(wrapperConfig)
-        val output = ByteArrayOutputStream()
-        val originalError = System.err
-
-        val result = try {
-            System.setErr(PrintStream(output))
-            nativeConfig.beforeSendList.single().run(
-                com.posthog.PostHogEvent(
-                    event = "checkout",
-                    distinctId = "user-1",
-                    properties = mutableMapOf()
-                )
-            )
-        } finally {
-            System.setErr(originalError)
-        }
-
-        assertNull(result)
-        assertTrue(output.toString().contains("[PostHog] Before-send callback failed; event was dropped."))
     }
 }

--- a/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
+++ b/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
@@ -197,7 +197,7 @@ private fun processBeforeSend(config: PostHogConfig, captureResult: JsAny?): JsA
     return try {
         val event = captureResult.toPostHogEvent() ?: return null
         val processed = config.runBeforeSend(event) {
-            if (config.debug) logWasmError("beforeSend", "callback failed and was ignored")
+            logWasmError("beforeSend", "callback failed; event was dropped")
         } ?: return null
 
         val processedProperties = processed.properties.toJsObject()

--- a/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
+++ b/posthog-kmp/src/wasmJsMain/kotlin/com/posthog/kmp/PostHog.wasmJs.kt
@@ -197,7 +197,7 @@ private fun processBeforeSend(config: PostHogConfig, captureResult: JsAny?): JsA
     return try {
         val event = captureResult.toPostHogEvent() ?: return null
         val processed = config.runBeforeSend(event) {
-            logWasmError("beforeSend", "callback failed; event was dropped")
+            if (config.debug) logWasmError("beforeSend", "callback failed; event was dropped")
         } ?: return null
 
         val processedProperties = processed.properties.toJsObject()

--- a/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
+++ b/posthog-kmp/src/wasmJsTest/kotlin/com/posthog/kmp/PostHogWasmJsTest.kt
@@ -75,7 +75,7 @@ class PostHogWasmJsTest {
             PostHogContext()
         )
 
-        val result = invokeBeforeSend(fakePostHog)
+        val result = assertNotNull(invokeBeforeSend(fakePostHog))
 
         assertEquals("sanitized", readJsString(result, "event"))
         assertEquals("anonymous", readDeepJsString(result, "properties", "distinct_id"))
@@ -91,20 +91,24 @@ class PostHogWasmJsTest {
 
     @Test
     fun beforeSendContainsCallbackAndConversionExceptions() {
+        var sentinelCalled = false
         PostHog.setup(
             PostHogConfig(
                 apiKey = "phc_test",
                 beforeSend = listOf(
+                    PostHogBeforeSend { it.copy(event = "transformed") },
                     PostHogBeforeSend { throw IllegalStateException("failed") },
-                    PostHogBeforeSend { it.copy(event = "continued") }
+                    PostHogBeforeSend {
+                        sentinelCalled = true
+                        it
+                    }
                 )
             ),
             PostHogContext()
         )
 
-        val result = invokeBeforeSend(fakePostHog)
-
-        assertEquals("continued", readJsString(result, "event"))
+        assertNull(invokeBeforeSend(fakePostHog))
+        assertFalse(sentinelCalled)
         assertNull(invokeBeforeSendWithThrowingGetter(fakePostHog))
     }
 
@@ -292,7 +296,7 @@ private fun readDeepBoolean(target: PostHogJsApi, parent: String, child: String,
 private fun readArrayString(target: PostHogJsApi, parent: String, child: String, index: Int): String = js("target[parent][child][index]")
 private fun readTimestamp(target: PostHogJsApi): Double = js("target.captureOptions.timestamp.getTime()")
 private fun readTimestampIso(target: PostHogJsApi): String = js("target.captureOptions.timestamp.toISOString()")
-private fun invokeBeforeSend(target: PostHogJsApi): JsAny = js(
+private fun invokeBeforeSend(target: PostHogJsApi): JsAny? = js(
     "target.options.before_send({ event: 'checkout', properties: { distinct_id: 'user-1', " +
         "email: 'person@example.com', plan: 'paid', nullable: null, nested: [['one'], ['two']], " +
         "date: new Date(0) } })"


### PR DESCRIPTION
## :bulb: Motivation and Context

A thrown `beforeSend` callback was logged and ignored. The SDK then continued the callback chain with the last valid event, which allowed an event to be queued after a hook failed.

This change makes callback failures fail closed. The SDK stops the callback chain and drops the event on every supported platform. Failure logging preserves the existing `config.debug` behavior, so disabling SDK logging remains authoritative.

## :green_heart: How did you test it?

- `./gradlew detekt :posthog-kmp:jvmTest :posthog-kmp:testAndroidHostTest :posthog-kmp:jsNodeTest :posthog-kmp:wasmJsBrowserTest :posthog-kmp:compileKotlinIosArm64 --no-daemon --console=plain`
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The implementation and PR preparation used Pi's worker agent and autoreview tool. The change follows the shared SDK contract chosen by the human DRI: a thrown hook must drop the event rather than resume with a fallback event. Existing debug logging controls are intentionally preserved. Autoreview found no actionable issues.
