### PR TITLE
fix(ios): send boolean event properties as JSON booleans

### DIFF
--- a/.changeset/ios-boolean-properties.md
+++ b/.changeset/ios-boolean-properties.md
@@ -1,0 +1,5 @@
+---
+"posthog-kmp": patch
+---
+
+Send boolean event properties as JSON booleans on iOS. They were serialized as `1`/`0`, which broke boolean property filters and split insight breakdowns across `true`/`false`/`1`/`0` buckets for apps shipping the same common code on Android and iOS. Properties set by the native iOS SDK, such as `$is_identified` and `$feature/<flag>`, were affected on every event.

--- a/.changeset/ios-boolean-properties.md
+++ b/.changeset/ios-boolean-properties.md
@@ -2,4 +2,4 @@
 "posthog-kmp": patch
 ---
 
-Fix boolean event properties being sent as `1`/`0` instead of `true`/`false` on iOS — existing insights and filters written against the numeric values need updating.
+Fix boolean event properties being sent as `1`/`0` instead of `true`/`false` on iOS — events captured by earlier versions keep the numeric values, so filters and breakdowns on those properties should match both (`true` or `1`, `false` or `0`) until that data ages out.

--- a/.changeset/ios-boolean-properties.md
+++ b/.changeset/ios-boolean-properties.md
@@ -4,6 +4,6 @@
 
 Send boolean event properties as JSON booleans on iOS. They were serialized as `1`/`0`, which broke boolean property filters and split insight breakdowns across `true`/`false`/`1`/`0` buckets for apps shipping the same common code on Android and iOS.
 
-Properties set by the native iOS SDK were affected on every event, whether or not the app captured a boolean itself: `$is_identified`, `$process_person_profile`, `$is_emulator`, `$network_wifi`, `$network_cellular`, `$is_testflight`, `$is_sideloaded`, `$is_ios_running_on_mac`, `$is_mac_catalyst_app` and `$feature/<flag>`. Null-valued properties the native SDK sets, such as `$feature_flag_response` for an absent flag, are no longer dropped either.
+Properties set by the native iOS SDK were affected too, whether or not the app captured a boolean itself: `$is_identified`, `$process_person_profile`, `$is_emulator`, `$network_wifi`, `$network_cellular`, `$is_testflight`, `$is_sideloaded`, `$is_ios_running_on_mac`, `$is_mac_catalyst_app` and `$feature/<flag>`. Null-valued properties the native SDK sets, such as `$feature_flag_response` for an absent flag, are no longer dropped either.
 
-Existing iOS events keep their numeric values, so insights, filters and cohorts written against `1`/`0` need updating and will show both buckets until the old data ages out.
+Existing iOS events keep their numeric values, so insights, filters and cohorts written against `1`/`0` need updating and will show both buckets until the old data ages out. Boolean super properties registered by an earlier version are stored as numbers on disk and keep going out that way until `register` is called again.

--- a/.changeset/ios-boolean-properties.md
+++ b/.changeset/ios-boolean-properties.md
@@ -2,4 +2,4 @@
 "posthog-kmp": patch
 ---
 
-Fix boolean properties being sent as `1`/`0` instead of `true`/`false` on iOS — values written by earlier versions do not match filters on the corrected property, so set its type to Boolean under Data management and set any person, group or super property holding one again.
+Fix boolean properties being sent as `1`/`0` instead of `true`/`false` on iOS — existing filters need the property type set to Boolean under Data management, and anonymous events now correctly skip person profiles when `personProfiles` is `identifiedOnly`.

--- a/.changeset/ios-boolean-properties.md
+++ b/.changeset/ios-boolean-properties.md
@@ -2,4 +2,8 @@
 "posthog-kmp": patch
 ---
 
-Send boolean event properties as JSON booleans on iOS. They were serialized as `1`/`0`, which broke boolean property filters and split insight breakdowns across `true`/`false`/`1`/`0` buckets for apps shipping the same common code on Android and iOS. Properties set by the native iOS SDK, such as `$is_identified` and `$feature/<flag>`, were affected on every event.
+Send boolean event properties as JSON booleans on iOS. They were serialized as `1`/`0`, which broke boolean property filters and split insight breakdowns across `true`/`false`/`1`/`0` buckets for apps shipping the same common code on Android and iOS.
+
+Properties set by the native iOS SDK were affected on every event, whether or not the app captured a boolean itself: `$is_identified`, `$process_person_profile`, `$is_emulator`, `$network_wifi`, `$network_cellular`, `$is_testflight`, `$is_sideloaded`, `$is_ios_running_on_mac`, `$is_mac_catalyst_app` and `$feature/<flag>`. Null-valued properties the native SDK sets, such as `$feature_flag_response` for an absent flag, are no longer dropped either.
+
+Existing iOS events keep their numeric values, so insights, filters and cohorts written against `1`/`0` need updating and will show both buckets until the old data ages out.

--- a/.changeset/ios-boolean-properties.md
+++ b/.changeset/ios-boolean-properties.md
@@ -2,4 +2,4 @@
 "posthog-kmp": patch
 ---
 
-Fix boolean properties being sent as `1`/`0` instead of `true`/`false` on iOS — filters should match both (`true` or `1`) until the values written by earlier versions are replaced, which for person, group and super properties only happens when they are set again.
+Fix boolean properties being sent as `1`/`0` instead of `true`/`false` on iOS — values written by earlier versions do not match filters on the corrected property, so set its type to Boolean under Data management and set any person, group or super property holding one again.

--- a/.changeset/ios-boolean-properties.md
+++ b/.changeset/ios-boolean-properties.md
@@ -2,8 +2,4 @@
 "posthog-kmp": patch
 ---
 
-Send boolean event properties as JSON booleans on iOS. They were serialized as `1`/`0`, which broke boolean property filters and split insight breakdowns across `true`/`false`/`1`/`0` buckets for apps shipping the same common code on Android and iOS.
-
-Properties set by the native iOS SDK were affected too, whether or not the app captured a boolean itself: `$is_identified`, `$process_person_profile`, `$is_emulator`, `$network_wifi`, `$network_cellular`, `$is_testflight`, `$is_sideloaded`, `$is_ios_running_on_mac`, `$is_mac_catalyst_app` and `$feature/<flag>`. Null-valued properties the native SDK sets, such as `$feature_flag_response` for an absent flag, are no longer dropped either.
-
-Existing iOS events keep their numeric values, so insights, filters and cohorts written against `1`/`0` need updating and will show both buckets until the old data ages out. Boolean super properties registered by an earlier version are stored as numbers on disk and keep going out that way until `register` is called again.
+Fix boolean event properties being sent as `1`/`0` instead of `true`/`false` on iOS — existing insights and filters written against the numeric values need updating.

--- a/.changeset/ios-boolean-properties.md
+++ b/.changeset/ios-boolean-properties.md
@@ -2,4 +2,4 @@
 "posthog-kmp": patch
 ---
 
-Fix boolean event properties being sent as `1`/`0` instead of `true`/`false` on iOS — events captured by earlier versions keep the numeric values, so filters and breakdowns on those properties should match both (`true` or `1`, `false` or `0`) until that data ages out.
+Fix boolean properties being sent as `1`/`0` instead of `true`/`false` on iOS — filters should match both (`true` or `1`) until the values written by earlier versions are replaced, which for person, group and super properties only happens when they are set again.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Build iOS
         run: ./gradlew :posthog-kmp:compileKotlinIosArm64 --no-daemon
 
+      - name: Run iOS unit tests
+        run: ./gradlew :posthog-kmp:iosSimulatorArm64Test --no-daemon
+
       - name: Regenerate iOS linkage package
         env:
           XCODEPROJ_PATH: ${{ github.workspace }}/sample/iosApp/iosApp.xcodeproj

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
@@ -36,7 +36,6 @@ private fun parseJsonArray(literal: String): List<*>? {
 /**
  * Matches the deepest structure `JSONSerialization` accepts: past it the payload is already unusable
  * to the native SDK, and stopping any earlier would leave booleans below the bound as `1`/`0`.
- * Without a bound, a self-referential property value recurses until the stack runs out.
  */
 private const val MAX_DEPTH = 512
 
@@ -44,27 +43,32 @@ private const val MAX_DEPTH = 512
  * Rebuilds the map so Kotlin booleans, including those nested in maps and lists, become real
  * `CFBoolean`s. Every other value is passed through untouched.
  */
-internal fun Map<String, Any?>.toNativeProperties(): Map<Any?, *> = toNativeDictionary(0)
+internal fun Map<String, Any?>.toNativeProperties(): Map<Any?, *> = toNativeDictionary(ArrayList())
 
-private fun Map<*, *>.toNativeDictionary(depth: Int): Map<Any?, *> {
+private fun Map<*, *>.toNativeDictionary(ancestors: ArrayList<Any>): Map<Any?, *> {
     val keys = ArrayList<Any?>(size)
     val values = NSMutableArray()
     for ((key, value) in this) {
         keys.add(key)
-        values.appendNative(value, depth)
+        values.appendNative(value, ancestors)
     }
     return NSDictionary.dictionaryWithObjects(values.copy() as List<*>, forKeys = keys)
 }
 
-private fun List<*>.toNativeArray(depth: Int): List<*> {
+private fun List<*>.toNativeArray(ancestors: ArrayList<Any>): List<*> {
     val values = NSMutableArray()
     for (value in this) {
-        values.appendNative(value, depth)
+        values.appendNative(value, ancestors)
     }
     return values.copy() as List<*>
 }
 
-private fun NSMutableArray.appendNative(value: Any?, depth: Int) {
+/**
+ * [ancestors] holds the containers currently being copied, innermost last. Depth alone does not
+ * bound a cycle: a container holding itself twice branches at every level, so it would be copied
+ * `2^MAX_DEPTH` times before the depth bound could stop it.
+ */
+private fun NSMutableArray.appendNative(value: Any?, ancestors: ArrayList<Any>) {
     when {
         value == null -> addObject(NSNull())
         value is Boolean -> {
@@ -72,9 +76,25 @@ private fun NSMutableArray.appendNative(value: Any?, depth: Int) {
             val box = if (value) trueBox else falseBox
             if (box != null) addObjectsFromArray(box) else addObject(value)
         }
-        depth >= MAX_DEPTH -> addObject(value)
-        value is Map<*, *> -> addObject(value.toNativeDictionary(depth + 1))
-        value is List<*> -> addObject(value.toNativeArray(depth + 1))
-        else -> addObject(value)
+        value !is Map<*, *> && value !is List<*> -> addObject(value)
+        // Handed over uncopied, for posthog-ios to reject as it did before this conversion existed.
+        ancestors.size >= MAX_DEPTH || ancestors.holds(value) -> addObject(value)
+        else -> {
+            ancestors.add(value)
+            val container = if (value is Map<*, *>) {
+                value.toNativeDictionary(ancestors)
+            } else {
+                (value as List<*>).toNativeArray(ancestors)
+            }
+            ancestors.removeAt(ancestors.size - 1)
+            addObject(container)
+        }
     }
+}
+
+private fun ArrayList<Any>.holds(value: Any): Boolean {
+    for (ancestor in this) {
+        if (ancestor === value) return true
+    }
+    return false
 }

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
@@ -1,0 +1,76 @@
+@file:OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
+
+package com.posthog.kmp
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSDictionary
+import platform.Foundation.NSJSONSerialization
+import platform.Foundation.NSMutableArray
+import platform.Foundation.NSNull
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.addObjectsFromArray
+import platform.Foundation.create
+import platform.Foundation.dataUsingEncoding
+import platform.Foundation.dictionaryWithObjects
+
+/**
+ * Kotlin/Native bridges a boxed Kotlin [Boolean] as `KotlinBoolean`, an `NSNumber` subclass that is
+ * not one of the `CFBoolean` singletons. `JSONSerialization` writes `true`/`false` only for
+ * `CFBoolean` and serializes every other `NSNumber` numerically, so a boolean property handed to the
+ * native SDK from Kotlin reaches PostHog as `1`/`0` while the same common code on Android sends
+ * `true`/`false`.
+ *
+ * A `CFBoolean` cannot be held in Kotlin: `NSNumber.numberWithBool`, `kCFBooleanTrue` and a boolean
+ * parsed out of JSON are all converted back to a Kotlin [Boolean] the moment they cross into Kotlin,
+ * and are re-boxed as `KotlinBoolean` on the way out again. The containers are therefore assembled on
+ * the Objective-C side from [trueBox]/[falseBox] and the boolean values are never read back.
+ */
+private val trueBox: List<*>? = parseJsonArray("[true]")
+private val falseBox: List<*>? = parseJsonArray("[false]")
+
+private fun parseJsonArray(literal: String): List<*>? {
+    val data = NSString.create(string = literal).dataUsingEncoding(NSUTF8StringEncoding) ?: return null
+    return NSJSONSerialization.JSONObjectWithData(data, 0uL, null) as? List<*>
+}
+
+/**
+ * Rebuilds the property map as an Objective-C dictionary in which Kotlin booleans, including those
+ * nested in maps and lists, are real `CFBoolean`s. All other values are passed through unchanged.
+ */
+internal fun Map<String, Any?>.toNativeProperties(): Map<Any?, *> = toNativeDictionary()
+
+private fun Map<*, *>.toNativeDictionary(): Map<Any?, *> {
+    val keys = ArrayList<Any?>(size)
+    val values = NSMutableArray()
+    for ((key, value) in this) {
+        keys.add(key)
+        values.appendNative(value)
+    }
+    return NSDictionary.dictionaryWithObjects(values.copy() as List<*>, forKeys = keys)
+}
+
+private fun List<*>.toNativeArray(): List<*> {
+    val values = NSMutableArray()
+    for (value in this) {
+        values.appendNative(value)
+    }
+    @Suppress("UNCHECKED_CAST")
+    return values.copy() as List<*>
+}
+
+private fun NSMutableArray.appendNative(value: Any?) {
+    when (value) {
+        null -> addObject(NSNull())
+        is Boolean -> {
+            // Copying out of a Foundation-built array keeps the CFBoolean singleton; falling back to
+            // the boxed Kotlin value only restores the 1/0 behaviour, it never fails.
+            val box = if (value) trueBox else falseBox
+            if (box != null) addObjectsFromArray(box) else addObject(value)
+        }
+        is Map<*, *> -> addObject(value.toNativeDictionary())
+        is List<*> -> addObject(value.toNativeArray())
+        else -> addObject(value)
+    }
+}

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
@@ -36,41 +36,49 @@ private fun parseJsonArray(literal: String): List<*>? {
 }
 
 /**
+ * Nesting deeper than this is handed to the native SDK as-is rather than rebuilt. Real payloads are
+ * tens of levels deep at most, so the only things this stops are pathological ones — a self
+ * referential property value would otherwise recurse until the stack runs out, where the native
+ * SDK's own `JSONSerialization` validation drops it and logs.
+ */
+private const val MAX_DEPTH = 64
+
+/**
  * Rebuilds the property map as an Objective-C dictionary in which Kotlin booleans, including those
  * nested in maps and lists, are real `CFBoolean`s. All other values are passed through unchanged.
  */
-internal fun Map<String, Any?>.toNativeProperties(): Map<Any?, *> = toNativeDictionary()
+internal fun Map<String, Any?>.toNativeProperties(): Map<Any?, *> = toNativeDictionary(0)
 
-private fun Map<*, *>.toNativeDictionary(): Map<Any?, *> {
+private fun Map<*, *>.toNativeDictionary(depth: Int): Map<Any?, *> {
     val keys = ArrayList<Any?>(size)
     val values = NSMutableArray()
     for ((key, value) in this) {
         keys.add(key)
-        values.appendNative(value)
+        values.appendNative(value, depth)
     }
     return NSDictionary.dictionaryWithObjects(values.copy() as List<*>, forKeys = keys)
 }
 
-private fun List<*>.toNativeArray(): List<*> {
+private fun List<*>.toNativeArray(depth: Int): List<*> {
     val values = NSMutableArray()
     for (value in this) {
-        values.appendNative(value)
+        values.appendNative(value, depth)
     }
-    @Suppress("UNCHECKED_CAST")
     return values.copy() as List<*>
 }
 
-private fun NSMutableArray.appendNative(value: Any?) {
-    when (value) {
-        null -> addObject(NSNull())
-        is Boolean -> {
+private fun NSMutableArray.appendNative(value: Any?, depth: Int) {
+    when {
+        value == null -> addObject(NSNull())
+        value is Boolean -> {
             // Copying out of a Foundation-built array keeps the CFBoolean singleton; falling back to
             // the boxed Kotlin value only restores the 1/0 behaviour, it never fails.
             val box = if (value) trueBox else falseBox
             if (box != null) addObjectsFromArray(box) else addObject(value)
         }
-        is Map<*, *> -> addObject(value.toNativeDictionary())
-        is List<*> -> addObject(value.toNativeArray())
+        depth >= MAX_DEPTH -> addObject(value)
+        value is Map<*, *> -> addObject(value.toNativeDictionary(depth + 1))
+        value is List<*> -> addObject(value.toNativeArray(depth + 1))
         else -> addObject(value)
     }
 }

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
@@ -17,15 +17,13 @@ import platform.Foundation.dictionaryWithObjects
 
 /**
  * Kotlin/Native bridges a boxed Kotlin [Boolean] as `KotlinBoolean`, an `NSNumber` subclass that is
- * not one of the `CFBoolean` singletons. `JSONSerialization` writes `true`/`false` only for
- * `CFBoolean` and serializes every other `NSNumber` numerically, so a boolean property handed to the
- * native SDK from Kotlin reaches PostHog as `1`/`0` while the same common code on Android sends
- * `true`/`false`.
+ * not one of the `CFBoolean` singletons, and `JSONSerialization` writes `true`/`false` only for
+ * `CFBoolean`. Boolean properties therefore reach PostHog as `1`/`0` from iOS while the same common
+ * code on Android sends `true`/`false`.
  *
  * A `CFBoolean` cannot be held in Kotlin: `NSNumber.numberWithBool`, `kCFBooleanTrue` and a boolean
- * parsed out of JSON are all converted back to a Kotlin [Boolean] the moment they cross into Kotlin,
- * and are re-boxed as `KotlinBoolean` on the way out again. The containers are therefore assembled on
- * the Objective-C side from [trueBox]/[falseBox] and the boolean values are never read back.
+ * parsed out of JSON all convert back to a Kotlin [Boolean] on arrival and re-box on the way out.
+ * The containers are assembled on the Objective-C side instead, and the values are never read back.
  */
 private val trueBox: List<*>? = parseJsonArray("[true]")
 private val falseBox: List<*>? = parseJsonArray("[false]")
@@ -36,17 +34,15 @@ private fun parseJsonArray(literal: String): List<*>? {
 }
 
 /**
- * The deepest structure `JSONSerialization` accepts, so anything past it is already unusable to the
- * native SDK. Nesting beyond this is handed over as-is instead of being recursed into — booleans
- * below that point stay `1`/`0`, which is why the bound tracks Foundation's rather than sitting
- * under it. Without any bound a self-referential property value recurses until the stack runs out,
- * where the native SDK's own validation drops the event and logs.
+ * Matches the deepest structure `JSONSerialization` accepts: past it the payload is already unusable
+ * to the native SDK, and stopping any earlier would leave booleans below the bound as `1`/`0`.
+ * Without a bound, a self-referential property value recurses until the stack runs out.
  */
 private const val MAX_DEPTH = 512
 
 /**
- * Rebuilds the property map as an Objective-C dictionary in which Kotlin booleans, including those
- * nested in maps and lists, are real `CFBoolean`s. All other values are passed through unchanged.
+ * Rebuilds the map so Kotlin booleans, including those nested in maps and lists, become real
+ * `CFBoolean`s. Every other value is passed through untouched.
  */
 internal fun Map<String, Any?>.toNativeProperties(): Map<Any?, *> = toNativeDictionary(0)
 
@@ -72,8 +68,7 @@ private fun NSMutableArray.appendNative(value: Any?, depth: Int) {
     when {
         value == null -> addObject(NSNull())
         value is Boolean -> {
-            // Copying out of a Foundation-built array keeps the CFBoolean singleton; falling back to
-            // the boxed Kotlin value only restores the 1/0 behaviour, it never fails.
+            // The fallback only restores the 1/0 behaviour; it never fails.
             val box = if (value) trueBox else falseBox
             if (box != null) addObjectsFromArray(box) else addObject(value)
         }

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/NativeProperties.ios.kt
@@ -36,12 +36,13 @@ private fun parseJsonArray(literal: String): List<*>? {
 }
 
 /**
- * Nesting deeper than this is handed to the native SDK as-is rather than rebuilt. Real payloads are
- * tens of levels deep at most, so the only things this stops are pathological ones — a self
- * referential property value would otherwise recurse until the stack runs out, where the native
- * SDK's own `JSONSerialization` validation drops it and logs.
+ * The deepest structure `JSONSerialization` accepts, so anything past it is already unusable to the
+ * native SDK. Nesting beyond this is handed over as-is instead of being recursed into — booleans
+ * below that point stay `1`/`0`, which is why the bound tracks Foundation's rather than sitting
+ * under it. Without any bound a self-referential property value recurses until the stack runs out,
+ * where the native SDK's own validation drops the event and logs.
  */
-private const val MAX_DEPTH = 64
+private const val MAX_DEPTH = 512
 
 /**
  * Rebuilds the property map as an Objective-C dictionary in which Kotlin booleans, including those

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -95,7 +95,6 @@ private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?)
     val properties = event.properties
         .filterKeys { it is String }
         .mapKeys { it.key as String }
-        .filterValues { it != null }
         .toMutableMap()
         .apply {
             this["\$lib"] = "posthog-kmp"
@@ -110,7 +109,9 @@ private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?)
 
     event.event = processed.event
     event.distinctId = processed.distinctId
-    event.properties = processed.properties.filterValues { it != null }.toNativeProperties()
+    // Rebuilding the whole tree costs ~10ms for a $snapshot payload. Skipping subtrees without
+    // booleans measures worse on real replay data, so this stays until it needs a cheaper answer.
+    event.properties = processed.properties.toNativeProperties()
     return event
 }
 
@@ -137,6 +138,7 @@ internal actual fun platformCapture(
         properties = properties?.toNativeProperties(),
         userProperties = null,
         userPropertiesSetOnce = null,
+        // Group values are strings; only booleans need rebuilding on the Objective-C side.
         groups = groups as? Map<Any?, *>,
         timestamp = timestamp?.toNSDate()
     )

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -85,9 +85,8 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
 private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?): NativePostHogEvent? {
     event ?: return null
     if (config.beforeSend.isEmpty()) {
-        // Nothing to hand to Kotlin, so stamp the metadata on the native dictionary instead of
-        // rebuilding it. Reading the properties into Kotlin and writing them back re-boxes every
-        // boolean the native SDK set (`$is_identified`, `$feature/<flag>`, ...) as a KotlinBoolean.
+        // Reading the properties into Kotlin and writing them back re-boxes every boolean the
+        // native SDK set, so stamp the metadata natively when no callback needs them in Kotlin.
         event.properties = event.properties.withSdkMetadata()
         return event
     }

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -109,8 +109,8 @@ private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?)
 
     event.event = processed.event
     event.distinctId = processed.distinctId
-    // Rebuilding the whole tree costs ~10ms for a $snapshot payload. Skipping subtrees without
-    // booleans measures worse on real replay data, so this stays until it needs a cheaper answer.
+    // Rebuilding the whole tree costs ~10ms for a $snapshot payload; skipping subtrees without
+    // booleans measured worse on real replay data.
     event.properties = processed.properties.toNativeProperties()
     return event
 }

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -101,7 +101,7 @@ private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?)
         }
 
     val processed = config.runBeforeSend(
-        PostHogEvent(event.event, event.distinctId, properties)
+        PostHogEvent(event.event, event.distinctId, properties.toMap())
     ) {
         if (config.debug) NSLog("[PostHog] Before-send callback failed; event was dropped.")
     } ?: return null
@@ -110,11 +110,23 @@ private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?)
     event.distinctId = processed.distinctId
     // Only what the callback actually replaced is rebuilt. Carrying the rest over as the native
     // objects they already are keeps a $snapshot payload off the main thread's critical path.
-    event.properties = event.properties.withSdkMetadata(
-        removedKeys = properties.keys - processed.properties.keys,
-        changedValues = processed.properties.filter { (key, value) -> properties[key] !== value }
-    )
+    val (removedKeys, changedValues) = propertyDelta(properties, processed.properties)
+    event.properties = event.properties.withSdkMetadata(removedKeys, changedValues)
     return event
+}
+
+/**
+ * The keys a before-send callback removed, and the entries it added or replaced. Values are compared
+ * by identity: the map handed to the callback holds each value once, so anything it did not replace
+ * comes back as the same reference.
+ */
+internal fun propertyDelta(
+    before: Map<String, Any?>,
+    after: Map<String, Any?>
+): Pair<Set<String>, Map<String, Any?>> {
+    // An added key reads back as null from [before], so absence is tested apart from the value.
+    val changed = after.filter { (key, value) -> key !in before || before[key] !== value }
+    return (before.keys - after.keys) to changed
 }
 
 /**
@@ -127,9 +139,9 @@ internal fun Map<Any?, *>.withSdkMetadata(
 ): Map<Any?, *> {
     val stamped = NSMutableDictionary()
     stamped.addEntriesFromDictionary(this)
-    removedKeys.forEach { stamped.removeObjectForKey(it) }
     stamped.setValue("posthog-kmp", forKey = "\$lib")
     stamped.setValue(PostHogKmpVersion.VERSION, forKey = "\$lib_version")
+    removedKeys.forEach { stamped.removeObjectForKey(it) }
     if (changedValues.isNotEmpty()) {
         stamped.addEntriesFromDictionary(changedValues.toNativeProperties())
     }

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -5,7 +5,10 @@ package com.posthog.kmp
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDate
 import platform.Foundation.NSLog
+import platform.Foundation.NSMutableDictionary
+import platform.Foundation.addEntriesFromDictionary
 import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.setValue
 import swiftPMImport.com.posthog.posthog.kmp.BoxedBeforeSendBlock
 import swiftPMImport.com.posthog.posthog.kmp.PostHogConfig as NativePostHogConfig
 import swiftPMImport.com.posthog.posthog.kmp.PostHogEvent as NativePostHogEvent
@@ -81,6 +84,14 @@ internal actual fun platformSetup(config: PostHogConfig, context: PostHogContext
 
 private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?): NativePostHogEvent? {
     event ?: return null
+    if (config.beforeSend.isEmpty()) {
+        // Nothing to hand to Kotlin, so stamp the metadata on the native dictionary instead of
+        // rebuilding it. Reading the properties into Kotlin and writing them back re-boxes every
+        // boolean the native SDK set (`$is_identified`, `$feature/<flag>`, ...) as a KotlinBoolean.
+        event.properties = event.properties.withSdkMetadata()
+        return event
+    }
+
     val properties = event.properties
         .filterKeys { it is String }
         .mapKeys { it.key as String }
@@ -99,8 +110,18 @@ private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?)
 
     event.event = processed.event
     event.distinctId = processed.distinctId
-    event.properties = processed.properties.filterValues { it != null }
+    event.properties = processed.properties.filterValues { it != null }.toNativeProperties()
     return event
+}
+
+/** Adds the KMP SDK metadata to [this] without reading any of its values into Kotlin. */
+internal fun Map<Any?, *>.withSdkMetadata(): Map<Any?, *> {
+    val stamped = NSMutableDictionary()
+    stamped.addEntriesFromDictionary(this)
+    stamped.setValue("posthog-kmp", forKey = "\$lib")
+    stamped.setValue(PostHogKmpVersion.VERSION, forKey = "\$lib_version")
+    @Suppress("UNCHECKED_CAST")
+    return stamped.copy() as Map<Any?, *>
 }
 
 internal actual fun platformCapture(
@@ -113,7 +134,7 @@ internal actual fun platformCapture(
     PostHogSDK.shared.captureWithEvent(
         event = event,
         distinctId = null,
-        properties = properties as? Map<Any?, *>,
+        properties = properties?.toNativeProperties(),
         userProperties = null,
         userPropertiesSetOnce = null,
         groups = groups as? Map<Any?, *>,
@@ -124,18 +145,16 @@ internal actual fun platformCapture(
 internal fun Long.toNSDate(): NSDate = NSDate.dateWithTimeIntervalSince1970(toDouble() / 1000.0)
 
 internal actual fun platformScreen(screenName: String, properties: Map<String, Any>?) {
-    @Suppress("UNCHECKED_CAST")
-    PostHogSDK.shared.screenWithTitle(screenName, properties = properties as? Map<Any?, *>)
+    PostHogSDK.shared.screenWithTitle(screenName, properties = properties?.toNativeProperties())
 }
 
 internal actual fun platformCaptureException(
     throwable: Throwable,
     additionalProperties: Map<String, Any>?
 ) {
-    @Suppress("UNCHECKED_CAST")
     PostHogSDK.shared.captureExceptionWithNSException(
         exception = throwable.toNSException(),
-        properties = additionalProperties as? Map<Any?, *>
+        properties = additionalProperties?.toNativeProperties()
     )
 }
 
@@ -144,11 +163,10 @@ internal actual fun platformIdentify(
     userProperties: Map<String, Any>?,
     userPropertiesSetOnce: Map<String, Any>?
 ) {
-    @Suppress("UNCHECKED_CAST")
     PostHogSDK.shared.identifyWithDistinctId(
         distinctId,
-        userProperties = userProperties as? Map<Any?, *>,
-        userPropertiesSetOnce = userPropertiesSetOnce as? Map<Any?, *>
+        userProperties = userProperties?.toNativeProperties(),
+        userPropertiesSetOnce = userPropertiesSetOnce?.toNativeProperties()
     )
 }
 
@@ -163,7 +181,8 @@ internal actual fun platformReset() {
 internal actual fun platformGetDistinctId(): String? = PostHogSDK.shared.getDistinctId()
 
 internal actual fun platformRegister(key: String, value: Any) {
-    PostHogSDK.shared.registerProperties(mapOf(key to value))
+    // Super properties are persisted as JSON, so a re-boxed boolean stays a number for good.
+    PostHogSDK.shared.registerProperties(mapOf(key to value).toNativeProperties())
 }
 
 internal actual fun platformUnregister(key: String) {
@@ -175,8 +194,7 @@ internal actual fun platformGroup(
     key: String,
     groupProperties: Map<String, Any>?
 ) {
-    @Suppress("UNCHECKED_CAST")
-    PostHogSDK.shared.groupWithType(type, key, groupProperties as? Map<Any?, *>)
+    PostHogSDK.shared.groupWithType(type, key, groupProperties?.toNativeProperties())
 }
 
 internal actual fun platformIsFeatureEnabled(key: String, defaultValue: Boolean, sendFeatureFlagEvent: Boolean): Boolean {
@@ -248,9 +266,8 @@ internal actual fun platformSetPersonProperties(
     userProperties: Map<String, Any>?,
     userPropertiesSetOnce: Map<String, Any>?
 ) {
-    @Suppress("UNCHECKED_CAST")
     PostHogSDK.shared.setPersonPropertiesWithUserPropertiesToSet(
-        userProperties as? Map<Any?, *>,
-        userPropertiesToSetOnce = userPropertiesSetOnce as? Map<Any?, *>
+        userProperties?.toNativeProperties(),
+        userPropertiesToSetOnce = userPropertiesSetOnce?.toNativeProperties()
     )
 }

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -119,6 +119,9 @@ private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?)
  * The keys a before-send callback removed, and the entries it added or replaced. Values are compared
  * by identity: the map handed to the callback holds each value once, so anything it did not replace
  * comes back as the same reference.
+ *
+ * Setting a property to null removes it, as on Android and the JVM. Properties the native SDK set to
+ * `NSNull` are not replaced by that, since the callback hands them straight back.
  */
 internal fun propertyDelta(
     before: Map<String, Any?>,
@@ -126,7 +129,8 @@ internal fun propertyDelta(
 ): Pair<Set<String>, Map<String, Any?>> {
     // An added key reads back as null from [before], so absence is tested apart from the value.
     val changed = after.filter { (key, value) -> key !in before || before[key] !== value }
-    return (before.keys - after.keys) to changed
+    val nulled = changed.filterValues { it == null }.keys
+    return ((before.keys - after.keys) + nulled) to (changed - nulled)
 }
 
 /**

--- a/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
+++ b/posthog-kmp/src/iosMain/kotlin/com/posthog/kmp/PostHog.ios.kt
@@ -108,18 +108,31 @@ private fun processBeforeSend(config: PostHogConfig, event: NativePostHogEvent?)
 
     event.event = processed.event
     event.distinctId = processed.distinctId
-    // Rebuilding the whole tree costs ~10ms for a $snapshot payload; skipping subtrees without
-    // booleans measured worse on real replay data.
-    event.properties = processed.properties.toNativeProperties()
+    // Only what the callback actually replaced is rebuilt. Carrying the rest over as the native
+    // objects they already are keeps a $snapshot payload off the main thread's critical path.
+    event.properties = event.properties.withSdkMetadata(
+        removedKeys = properties.keys - processed.properties.keys,
+        changedValues = processed.properties.filter { (key, value) -> properties[key] !== value }
+    )
     return event
 }
 
-/** Adds the KMP SDK metadata to [this] without reading any of its values into Kotlin. */
-internal fun Map<Any?, *>.withSdkMetadata(): Map<Any?, *> {
+/**
+ * Adds the KMP SDK metadata to [this], along with whatever a before-send callback removed or
+ * replaced, without reading the values it already holds into Kotlin.
+ */
+internal fun Map<Any?, *>.withSdkMetadata(
+    removedKeys: Set<String> = emptySet(),
+    changedValues: Map<String, Any?> = emptyMap()
+): Map<Any?, *> {
     val stamped = NSMutableDictionary()
     stamped.addEntriesFromDictionary(this)
+    removedKeys.forEach { stamped.removeObjectForKey(it) }
     stamped.setValue("posthog-kmp", forKey = "\$lib")
     stamped.setValue(PostHogKmpVersion.VERSION, forKey = "\$lib_version")
+    if (changedValues.isNotEmpty()) {
+        stamped.addEntriesFromDictionary(changedValues.toNativeProperties())
+    }
     @Suppress("UNCHECKED_CAST")
     return stamped.copy() as Map<Any?, *>
 }

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
@@ -103,6 +103,37 @@ class NativePropertiesTest {
     }
 
     @Test
+    fun testPropertyDeltaFindsWhatTheCallbackChanged() {
+        val before = mapOf("kept" to "a", "replaced" to "old", "dropped" to 1)
+
+        val (removed, changed) = propertyDelta(before, before - "dropped" + mapOf("replaced" to "new", "added" to true))
+
+        assertEquals(setOf("dropped"), removed)
+        assertEquals(mapOf("replaced" to "new", "added" to true), changed)
+    }
+
+    @Test
+    fun testPropertyDeltaKeepsAValueAddedAsNull() {
+        val before = mapOf("kept" to "a")
+
+        val (removed, changed) = propertyDelta(before, before + ("added" to null))
+
+        assertEquals(emptySet(), removed)
+        assertEquals(mapOf("added" to null), changed)
+    }
+
+    @Test
+    fun testCallbackCanRemoveSdkMetadata() {
+        @Suppress("UNCHECKED_CAST")
+        val nativeProperties = parse("""{"kept":true}""") as Map<Any?, *>
+
+        assertEquals(
+            """{"kept":true}""",
+            json(nativeProperties.withSdkMetadata(removedKeys = setOf("${'$'}lib", "${'$'}lib_version")))
+        )
+    }
+
+    @Test
     fun testSdkMetadataStampAppliesCallbackChanges() {
         @Suppress("UNCHECKED_CAST")
         val nativeProperties = parse("""{"kept":true,"dropped":1,"replaced":"old"}""") as Map<Any?, *>

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
@@ -137,13 +137,30 @@ class NativePropertiesTest {
     }
 
     @Test
-    fun testPropertyDeltaKeepsAValueAddedAsNull() {
-        val before = mapOf("kept" to "a")
+    fun testPropertyDeltaTreatsANulledValueAsRemoved() {
+        val before = mapOf("kept" to "a", "nulled" to "b")
 
-        val (removed, changed) = propertyDelta(before, before + ("added" to null))
+        val (removed, changed) = propertyDelta(before, before + mapOf("nulled" to null, "added" to null))
+
+        assertEquals(setOf("nulled", "added"), removed)
+        assertEquals(emptyMap(), changed)
+    }
+
+    @Test
+    fun testPropertyDeltaKeepsNativeNullsTheCallbackHandsBack() {
+        @Suppress("UNCHECKED_CAST")
+        val native = parse("""{"${'$'}feature_flag_response":null,"kept":true}""") as Map<Any?, *>
+        val before = native.mapKeys { it.key as String }
+
+        val (removed, changed) = propertyDelta(before, before.toMap())
 
         assertEquals(emptySet(), removed)
-        assertEquals(mapOf("added" to null), changed)
+        assertEquals(emptyMap(), changed)
+        assertEquals(
+            """{"${'$'}feature_flag_response":null,"${'$'}lib":"posthog-kmp",""" +
+                """"${'$'}lib_version":"${PostHogKmpVersion.VERSION}","kept":true}""",
+            json(native.withSdkMetadata(removed, changed))
+        )
     }
 
     @Test

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
@@ -103,6 +103,23 @@ class NativePropertiesTest {
     }
 
     @Test
+    fun testSdkMetadataStampAppliesCallbackChanges() {
+        @Suppress("UNCHECKED_CAST")
+        val nativeProperties = parse("""{"kept":true,"dropped":1,"replaced":"old"}""") as Map<Any?, *>
+
+        val result = nativeProperties.withSdkMetadata(
+            removedKeys = setOf("dropped"),
+            changedValues = mapOf("replaced" to false, "added" to true)
+        )
+
+        assertEquals(
+            """{"${'$'}lib":"posthog-kmp","${'$'}lib_version":"${PostHogKmpVersion.VERSION}",""" +
+                """"added":true,"kept":true,"replaced":false}""",
+            json(result)
+        )
+    }
+
+    @Test
     fun testSdkMetadataStampKeepsNativeBooleans() {
         @Suppress("UNCHECKED_CAST")
         val nativeProperties = parse("""{"${'$'}is_identified":true,"${'$'}feature/beta":false}""") as Map<Any?, *>

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
@@ -12,6 +12,7 @@ import platform.Foundation.create
 import platform.Foundation.dataUsingEncoding
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 /**
  * The native SDK serializes event properties with `JSONSerialization`, so these tests assert on the
@@ -67,6 +68,40 @@ class NativePropertiesTest {
         assertEquals(
             """{"byte":1,"double":1.5,"int":2,"long":3,"null":null,"string":"yes"}""",
             json(properties.toNativeProperties())
+        )
+    }
+
+    @Test
+    fun testNullValuesArePreserved() {
+        // The native SDK sets NSNull-valued properties such as ${'$'}feature_flag_response; they survive
+        // the round trip as JSON null rather than being dropped.
+        assertEquals(
+            """{"absent":null}""",
+            json(mapOf("absent" to null).toNativeProperties())
+        )
+    }
+
+    @Test
+    fun testSelfReferentialValueDoesNotRecurseForever() {
+        val cycle = mutableListOf<Any?>()
+        cycle.add(cycle)
+
+        val converted = mapOf("cycle" to cycle).toNativeProperties()
+
+        // Handed to the native SDK intact past the depth cap, for its own serialization check to
+        // reject, which is what happened before these values were rebuilt here at all.
+        assertEquals(1, converted.size)
+        assertFalse(NSJSONSerialization.isValidJSONObject(converted))
+    }
+
+    @Test
+    fun testSdkMetadataStampOverwritesNativeSdkValues() {
+        @Suppress("UNCHECKED_CAST")
+        val nativeProperties = parse("""{"${'$'}lib":"posthog-ios","${'$'}lib_version":"3.64.1"}""") as Map<Any?, *>
+
+        assertEquals(
+            """{"${'$'}lib":"posthog-kmp","${'$'}lib_version":"${PostHogKmpVersion.VERSION}"}""",
+            json(nativeProperties.withSdkMetadata())
         )
     }
 

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
@@ -12,7 +12,7 @@ import platform.Foundation.create
 import platform.Foundation.dataUsingEncoding
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * The native SDK serializes event properties with `JSONSerialization`, so these tests assert on the
@@ -72,26 +72,23 @@ class NativePropertiesTest {
     }
 
     @Test
-    fun testNullValuesArePreserved() {
-        // The native SDK sets NSNull-valued properties such as ${'$'}feature_flag_response; they survive
-        // the round trip as JSON null rather than being dropped.
-        assertEquals(
-            """{"absent":null}""",
-            json(mapOf("absent" to null).toNativeProperties())
-        )
-    }
-
-    @Test
     fun testSelfReferentialValueDoesNotRecurseForever() {
         val cycle = mutableListOf<Any?>()
         cycle.add(cycle)
 
-        val converted = mapOf("cycle" to cycle).toNativeProperties()
+        // Returning at all is the assertion: unbounded, this exhausts the stack.
+        assertEquals(1, mapOf("cycle" to cycle).toNativeProperties().size)
+    }
 
-        // Handed to the native SDK intact past the depth cap, for its own serialization check to
-        // reject, which is what happened before these values were rebuilt here at all.
-        assertEquals(1, converted.size)
-        assertFalse(NSJSONSerialization.isValidJSONObject(converted))
+    @Test
+    fun testDeeplyNestedBooleansAreStillConverted() {
+        var nested: Any = mapOf("flag" to true)
+        repeat(400) { nested = mapOf("nested" to nested) }
+
+        val converted = mapOf("deep" to nested).toNativeProperties()
+
+        assertTrue(NSJSONSerialization.isValidJSONObject(converted))
+        assertTrue(json(converted).contains(""""flag":true"""))
     }
 
     @Test

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
@@ -81,6 +81,30 @@ class NativePropertiesTest {
     }
 
     @Test
+    fun testBranchingCycleDoesNotCopyExponentially() {
+        val cycle = mutableListOf<Any?>()
+        cycle.add(cycle)
+        cycle.add(cycle)
+        val nested = mutableMapOf<String, Any?>()
+        nested["self"] = nested
+        nested["also"] = mapOf("back" to nested)
+
+        // Returning promptly is the assertion: bounded only by depth, each of these branches at
+        // every level and never finishes.
+        assertEquals(2, mapOf("list" to cycle, "map" to nested).toNativeProperties().size)
+    }
+
+    @Test
+    fun testRepeatedValueOutsideACycleIsStillConverted() {
+        val shared = mapOf("on" to true)
+
+        assertEquals(
+            """{"a":{"on":true},"b":{"on":true}}""",
+            json(mapOf("a" to shared, "b" to shared).toNativeProperties())
+        )
+    }
+
+    @Test
     fun testDeeplyNestedBooleansAreStillConverted() {
         var nested: Any = mapOf("flag" to true)
         repeat(400) { nested = mapOf("nested" to nested) }

--- a/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
+++ b/posthog-kmp/src/iosTest/kotlin/com/posthog/kmp/NativePropertiesTest.kt
@@ -1,0 +1,86 @@
+@file:OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
+
+package com.posthog.kmp
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSJSONSerialization
+import platform.Foundation.NSJSONWritingSortedKeys
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
+import platform.Foundation.dataUsingEncoding
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The native SDK serializes event properties with `JSONSerialization`, so these tests assert on the
+ * JSON text it would produce rather than on the values, which Kotlin converts back on the way in.
+ */
+class NativePropertiesTest {
+
+    private fun json(value: Any): String {
+        val data = NSJSONSerialization.dataWithJSONObject(value, NSJSONWritingSortedKeys, null)!!
+        return NSString.create(data, NSUTF8StringEncoding).toString()
+    }
+
+    private fun parse(literal: String): Any =
+        NSJSONSerialization.JSONObjectWithData(
+            NSString.create(string = literal).dataUsingEncoding(NSUTF8StringEncoding)!!,
+            0uL,
+            null
+        )!!
+
+    @Test
+    fun testBooleansSerializeAsJsonBooleans() {
+        assertEquals(
+            """{"disabled":false,"enabled":true}""",
+            json(mapOf("enabled" to true, "disabled" to false).toNativeProperties())
+        )
+    }
+
+    @Test
+    fun testNestedBooleansSerializeAsJsonBooleans() {
+        val properties = mapOf(
+            "${'$'}set" to mapOf("is_pro" to true),
+            "flags" to listOf(true, false),
+            "deep" to listOf(mapOf("on" to true))
+        )
+
+        assertEquals(
+            """{"${'$'}set":{"is_pro":true},"deep":[{"on":true}],"flags":[true,false]}""",
+            json(properties.toNativeProperties())
+        )
+    }
+
+    @Test
+    fun testOtherValueTypesAreUnchanged() {
+        val properties = mapOf(
+            "byte" to 1.toByte(),
+            "double" to 1.5,
+            "int" to 2,
+            "long" to 3L,
+            "null" to null,
+            "string" to "yes"
+        )
+
+        assertEquals(
+            """{"byte":1,"double":1.5,"int":2,"long":3,"null":null,"string":"yes"}""",
+            json(properties.toNativeProperties())
+        )
+    }
+
+    @Test
+    fun testSdkMetadataStampKeepsNativeBooleans() {
+        @Suppress("UNCHECKED_CAST")
+        val nativeProperties = parse("""{"${'$'}is_identified":true,"${'$'}feature/beta":false}""") as Map<Any?, *>
+
+        val stamped = nativeProperties.withSdkMetadata()
+
+        assertEquals(
+            """{"${'$'}feature\/beta":false,"${'$'}is_identified":true,""" +
+                """"${'$'}lib":"posthog-kmp","${'$'}lib_version":"${PostHogKmpVersion.VERSION}"}""",
+            json(stamped)
+        )
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #68.

Boolean event properties captured from `commonMain` arrive in PostHog as `1`/`0` on iOS while the same common code sends `true`/`false` on Android, so a single property ends up with mixed value types — boolean filters break and insight breakdowns split across `true`/`false`/`1`/`0`.

Kotlin/Native bridges a boxed Kotlin `Boolean` as `KotlinBoolean`, an `NSNumber` subclass that is **not** one of the `CFBoolean` singletons. `JSONSerialization` writes `true`/`false` only for `CFBoolean` and serializes every other `NSNumber` numerically, so the boolean hits the wire as a number.

Two things worth flagging beyond the issue report:

**1. The workaround suggested in the issue does not work.** `NSNumber.numberWithBool()` called *from Kotlin* returns a value that Kotlin/Native converts straight back to a Kotlin `Boolean`, which is then re-boxed as `KotlinBoolean` on the way out. The same is true for `kCFBooleanTrue` and for a boolean parsed out of JSON: a `CFBoolean` simply cannot be held in a Kotlin variable. The containers therefore have to be assembled on the Objective-C side, which is what `toNativeProperties()` does — it never reads the boolean values back.

**2. The bug also corrupted properties the native SDK sets itself.** `processBeforeSend` is registered unconditionally (to stamp `$lib`/`$lib_version`) and rewrote the *entire* property dictionary through Kotlin on every event, after `buildProperties` had already run. That re-boxed nine native booleans on every single event. Baseline payload from `main`:

```json
"$is_testflight":0,"$is_identified":0,"$process_person_profile":0,"$is_emulator":1,
"$network_wifi":1,"$network_cellular":0,"$is_sideloaded":0,
"$is_ios_running_on_mac":0,"$is_mac_catalyst_app":0
```

When no user `beforeSend` callback is configured, the SDK metadata is now stamped onto the native dictionary instead of round-tripping it through Kotlin, so those values are never converted. That path is also cheaper than what it replaces.

`platformRegister` is normalized separately because super properties are persisted to disk as JSON — a boolean re-boxed there stays a number permanently, and no `beforeSend` fix can recover it.

## Upgrade impact

Kept out of the change intent so the changelog line stays scannable. Traced through the PostHog source, and the filter behaviour was confirmed by evaluating the compiled expressions against a live project rather than reasoning about them.

- **Old and new values cannot both match one filter.** A property definition's type is inferred once and never re-inferred — the upsert sets `property_type` only `WHERE property_type IS NULL` (`rust/property-defs-rs/src/batch_ingestion.rs:663-667`). On a `Boolean` definition a stored `1` compiles to `toBool(transform(toString(prop), ['true','false'], [1,0], NULL))`, which evaluates to `NULL`; on a `Numeric` definition a stored `true` compiles to `toFloat(prop)`, also `NULL`, which additionally makes those events read as **is not set**. The left-hand side is NULL either way, so listing both `true` and `1` does not help. A project that was iOS-only has these properties typed `Numeric` and needs the type changed to Boolean under Data management → Properties. A project that also ships Android already has them typed `Boolean`, so its iOS events simply start matching filters that never worked before.
- **Only event properties age out.** Person properties (`identify`, `setPersonProperties`), group properties (`group`) and super properties (`register`) persist until they are set again — a dormant user keeps `1` on their person record indefinitely. Super properties are additionally stored on disk as JSON, so they keep going out as numbers until `register` is called again. A `$set_once` boolean written as `1` can never be corrected, since the check is presence-only (`person-update.ts:162`); it needs an explicit `$set` backfill. Plain `$set` self-heals on the next write, because `1 !== true`.
- **Anonymous iOS events stop creating person profiles.** `$process_person_profile` is one of the booleans the old round-trip corrupted, and ingestion compares it strictly against `false` (`person-utils.ts:16-30`), so `0` meant *create the profile* — overriding `personProfiles = identifiedOnly`, which is the KMP default. After this fix, person counts stop growing from anonymous iOS traffic, the sampled `invalid_process_person_profile` ingestion warnings stop, and the enhanced-persons usage metric drops, since it counts only `person_mode IN ('full', 'force_upgrade')`. This was invisible in the data because ingestion deletes the key before storing the event.
- Null-valued properties the native SDK sets, such as `$feature_flag_response` for an absent flag, now reach the wire as `null` instead of being dropped. Cosmetic for filtering: present-but-null is treated exactly like absent, confirmed by evaluating `nullIf(nullIf(JSONExtractRaw(...), ''), 'null')` and `is set` against a live project.

## :green_heart: How did you test it?

**Unit tests** — new `NativePropertiesTest` in `iosTest`, asserting on the JSON text `JSONSerialization` produces (the values themselves are converted back on the way into Kotlin, so they can't be asserted on directly): top-level booleans, booleans nested in maps and lists, other value types left unchanged (`Byte` in particular must not become a boolean), and the metadata stamp preserving native booleans.

`iosTest` was never wired into CI — the iOS job only compiled. This PR adds `:posthog-kmp:iosSimulatorArm64Test` to it, so the new tests and the two existing iOS test classes now actually run. 27 tests pass locally on `iosSimulatorArm64`.

**End-to-end** — a throwaway test (not committed) set up the SDK, captured `mapOf("my_flag" to true, "off_flag" to false, "count" to 7)`, and read the queued event straight off disk. Same harness, before and after:

| | payload |
|---|---|
| `main` | `"my_flag":1,"off_flag":0,"count":7` plus the nine native booleans as `0`/`1` |
| this branch | `"my_flag":true,"off_flag":false,"count":7` plus `"$is_identified":false,"$is_emulator":true,"$network_wifi":true,…` |

Also run: `detekt` clean, `compileKotlinIosArm64` / `compileKotlinIosX64` with no new warnings, `jvmTest` green.

**Review pass.** Two independent reviews were run over this branch, each re-verifying the load-bearing claim by compiling and running standalone Kotlin/Native programs rather than taking it on faith. Both confirmed that `NSNumber.numberWithBool()`, `kCFBooleanTrue` via `interpretObjCPointer`, and a boolean read out of parsed JSON all come back as `kotlin.Boolean` and re-box as `1` — so the Objective-C-side assembly here is the only construction that survives, and the workaround suggested in #68 does not work. Two findings were real and are fixed in the second commit:

- **Null-valued properties.** posthog-ios sets `$feature_flag_response`, `$feature_flag_reason`, `$feature_flag_id` and `$feature_flag_version` to `NSNull` for an absent flag. `NSNull` reads back into Kotlin as `null`, so `filterValues { it != null }` dropped those keys. The metadata fast path kept them while the before-send path stripped them, which made event contents depend on whether the app registered a callback. Both paths keep them now.
- **Unbounded recursion.** A self-referential property value crashed the host app, where posthog-ios previously dropped the key and logged, because the conversion now runs before its `isValidObject` guard. Verified: uncapped `exit=139`, capped `exit=0`. Nesting past 64 levels is handed over unconverted for that guard to reject, as it did before.

A second review pass then caught that the depth bound I'd added was itself miscalibrated: `JSONSerialization` accepts 511 container levels, so between 65 and 511 a payload stayed serializable while the booleans inside it silently reverted to `1`/`0` — reachable through session replay, where wireframe trees nest two levels per view and carry `disabled`/`checked` booleans. The bound now tracks Foundation's, verified at that limit on a secondary thread (where the native SDK may run before-send callbacks): `valid=true keepsBoolean=true`. That pass also removed a test that duplicated an existing case while appearing to cover the null-property change, and replaced assertions that were really testing Foundation's depth limit with one that pins this bound.

Findings raised and retracted after falsification: `dictionaryWithObjects:forKeys:` raising on a nil key (a Kotlin `null` key bridges to `NSNull`, never nil), the dropped `filterKeys { it is String }` (native properties are `[String: Any]`), and `trueBox`/`falseBox` thread-safety (initialized once, and the `CFBoolean`s are process-wide singletons either way).

Not tested: a real device, and a user-supplied `beforeSend` callback end to end (the writeback path it takes is covered by the unit tests). `processBeforeSend` has no direct test because posthog-ios's `PostHogEvent` initializer is not public, so a native event cannot be constructed from Kotlin; the testable half is covered through `withSdkMetadata`.

**Session replay:** snapshots are generated on the main thread (`PostHogReplayIntegration.swift:1372`) and throttled to one a second, so rebuilding their property tree there would have been a stall repeating once a second for apps that also register a `beforeSend` callback. The writeback now compares top-level values by identity and rebuilds only what the callback actually replaced; everything else carries over as the native objects it already is. Independently measured on an 8,845-node replay payload: **1884 µs → 1.9 µs** when the callback leaves properties alone, 2.6 µs with one property replaced. A callback that replaces every value costs 3.5% over the old path, so the optimization never meaningfully regresses.

That optimization was reviewed separately, since it landed after the two earlier rounds. The review found two defects in it, both fixed in `9c895a5`: a property *added* with a `null` value was dropped (an added key reads back as `null` from the map handed to the callback, so it compared equal to its own absence), and the SDK metadata was stamped after the callback's removals, making `$lib` removal a silent no-op while overwriting it still worked — incoherent, and out of parity with JS and JVM which both honour removal. The diff was also extracted from a `private` function taking a native event type Kotlin cannot construct, so it is now covered by tests that fail against the pre-fix implementation.

A final round covered the review feedback on this PR and a fresh pass over the branch. Three changes came out of it:

- **Cycle detection (`4ba7206`).** The depth bound stopped a self-reference that recursed in a straight line, but not one that branches: a container holding itself twice is copied `2^512` times before the bound can return, so capture pegs the CPU instead of letting posthog-ios reject the value. The conversion now tracks the containers it is inside and hands a repeat back uncopied, exactly as the depth bound does. Verified in both directions — the new test does not finish within 300s against the pre-fix source, and passes in about a second after. The bound stays as the stack guard for legitimately deep acyclic payloads; Foundation's real write limit was measured at 511 levels, so `MAX_DEPTH = 512` sits on the safe side.
- **Callback nulls (`ef930aa`).** Dropping null values on the way out was lost when the writeback became a diff, so a callback setting a property to `null` started emitting an explicit `null` on iOS while the same shared-code callback still removed the key on Android and the JVM. Nulling a property removes it again. Properties the native SDK set to `NSNull` are untouched, since the callback hands those back unchanged and they never enter the diff. The logic lives in `propertyDelta` rather than `processBeforeSend`, because the latter takes a native event type Kotlin cannot construct and so cannot be tested.
- **Change intent (`17e6c98`, `1413154`, `d751bfb`).** Rewritten twice as the upgrade impact above was actually verified: first because the stale values are not limited to events and do not age out, then because telling users to match both `true` and `1` is not advice that works on a typed property.

Neither reviewer found a blocker in the cycle-detection change itself. The adversarial pass confirmed the push/pop balance, that there is no off-by-one against the old `depth` parameter, that identity comparison cannot produce a false positive, and that a detected cycle is still dropped and logged by posthog-ios's `sanitizeDictionary` rather than slipping through to `JSONSerialization`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm change` to generate a change intent file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). The investigation ran first as `/investigate-github-issue` on #68 and confirmed the report against `main`; the root-cause claim was then verified empirically rather than from reasoning, by compiling small Kotlin/Native programs against `kotlinc-native` and serializing the exact map shapes that cross the boundary.

Approaches tried and rejected along the way:

- **A Swift shim in the SwiftPM bridge**, which is where a normalizer would naturally live. Rejected: `PostHogBridge.swift` was deleted in #65 when the build moved to Kotlin's built-in `swiftPMDependencies`, and re-adding a local Swift package to a build that had just been simplified to remove one seemed like the wrong trade for this bug.
- **Holding a `CFBoolean` in Kotlin** via `NSNumber.numberWithBool`, `interpretObjCPointer(kCFBooleanTrue)`, or a JSON round trip. All three measurably come back as Kotlin `Boolean` and re-box — this is also why the workaround in the issue doesn't help.
- **A CoreFoundation route** (`CFDictionaryCreateMutable` + `CFDictionarySetValue` + toll-free bridge). It works, but needs manual `CFRelease`/`interpretObjCPointer` handling; the Foundation-only route in this PR is equivalent and has no lifetime concerns.
- **Normalizing everything at the `beforeSend` writeback**, which would have been a one-line fix covering all surfaces. Rejected because it deep-walks every event's properties, including large `$snapshot` payloads for session-replay users.

One judgement call worth a reviewer's eye: `withSdkMetadata` is `internal` rather than `private` so `iosTest` can assert on it.






